### PR TITLE
Add project meta files

### DIFF
--- a/.claude/commands/iterate.md
+++ b/.claude/commands/iterate.md
@@ -1,0 +1,37 @@
+---
+description: Iterate through a list of changes — one branch + PR + merge per item
+---
+
+You will execute a series of changes provided by the user, one at a time. Each item becomes its own branch, PR, and merge commit on master.
+
+## Preflight (run once, before the first item)
+
+1. Confirm `gh` is installed and authenticated: `gh auth status`. If not, abort and tell the user to run `sudo apt install gh && gh auth login`.
+2. Confirm clean working tree: `git status --porcelain` must be empty. If dirty, abort and ask the user how to proceed.
+3. Sync master: `git checkout master && git pull`.
+4. Determine the starting branch number: `git branch -a --list 'origin/fix/*' 'fix/*'` and parse the highest N from `fix/N-*` patterns. Next item uses N+1. (If no `fix/*` branches exist, start at 1.)
+
+## Per-item loop
+
+For each item in the list, in order:
+
+1. **Slug** — generate a kebab-case slug from the item title (3–5 words, lowercase, hyphens, no punctuation).
+2. **Branch** — `git checkout -b fix/N-slug` from latest master. Increment N for the next item.
+3. **Implement** — make the changes. **If the item has logically separate parts, make multiple focused commits** (one per part). Don't lump unrelated work into one commit.
+4. **Push** — `git push -u origin fix/N-slug`.
+5. **Open PR** — `gh pr create` using `.github/pull_request_template.md`. Title under 70 chars, imperative mood (e.g. "Fix Monocraft toggle persistence"). Body fills in Summary / Why / Test plan from the item context.
+6. **Merge** — `gh pr merge --merge --delete-branch`. **Always `--merge`** (keeps the per-part commits and adds a merge commit). Never `--squash` or `--rebase`.
+7. **Return to master** — `git checkout master && git pull`.
+8. **Continue** to the next item.
+
+## Hard rules
+
+- Never skip the master sync between items — every branch must stem from the latest master.
+- Never use `--squash` or `--rebase` on merge — always `--merge`.
+- If any step fails (push rejected, PR check failure, merge conflict, etc.), **STOP** and report the failure. Do not silently continue to the next item.
+- Don't batch multiple items into one branch, even if they look related. One item = one branch = one PR.
+- Follow the project's CLAUDE.md coding rules for every change.
+
+## The list
+
+$ARGUMENTS

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,41 @@
+# Why this file exists: contributors work across Windows + WSL + macOS,
+# and tools like `cargo update` on Windows rewrite Cargo.lock with native
+# CRLF endings, which then shows up as a full-file diff against a repo
+# that's otherwise LF. Locking text files to LF (with the right Windows-
+# native exceptions) keeps the diff signal honest and the release script
+# reproducible.
+
+# Default: detect text, normalize to LF in the repo + working tree.
+* text=auto eol=lf
+
+# Windows-native script formats keep CRLF; running them under cmd.exe /
+# PowerShell with bare LF endings is unreliable.
+*.bat   text eol=crlf
+*.cmd   text eol=crlf
+*.ps1   text eol=crlf
+
+# Tell git these are binary so it doesn't try to diff or normalize.
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.gif   binary
+*.ico   binary
+*.icns  binary
+*.ttf   binary
+*.otf   binary
+*.woff  binary
+*.woff2 binary
+*.jar   binary
+*.zip   binary
+*.gz    binary
+*.tar   binary
+*.exe   binary
+*.msi   binary
+*.dll   binary
+*.so    binary
+*.dylib binary
+*.dmg   binary
+*.appimage binary
+*.deb   binary
+*.db    binary
+*.sqlite binary

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+## Summary
+-
+
+## Why
+
+
+## Test plan
+- [ ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,234 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        # Linux + macOS matrix entries are commented out for now to keep
+        # CI minutes spent on the OS that actually has users. Re-enable
+        # by uncommenting the relevant `include` block; the publish job
+        # below picks up whichever per-platform fragments land and
+        # combines them into latest.json automatically.
+        include:
+          - os: windows-latest
+            platform: windows-x86_64
+            # NSIS installer EXE produces a `-setup.exe` plus a sibling
+            # `-setup.exe.sig`. createUpdaterArtifacts: true on Tauri v2 signs
+            # the installer EXE directly (no .nsis.zip pair).
+            bundle_glob: '*-setup.exe'
+          # - os: ubuntu-latest
+          #   platform: linux-x86_64
+          #   bundle_glob: '*.AppImage'
+          #   apt_packages: >-
+          #     libwebkit2gtk-4.1-dev
+          #     libgtk-3-dev
+          #     libayatana-appindicator3-dev
+          #     librsvg2-dev
+          #     build-essential
+          #     pkg-config
+          # - os: macos-latest
+          #   platform: darwin-aarch64
+          #   bundle_glob: '*.app.tar.gz'
+
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Install Linux build deps
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ${{ matrix.apt_packages }}
+
+      - name: Fetch mpv sidecar (Windows)
+        if: matrix.platform == 'windows-x86_64'
+        shell: pwsh
+        env:
+          # Pin to a known-good upstream release. Bump deliberately.
+          MPV_VERSION: '0.41.0'
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $url = "https://github.com/mpv-player/mpv/releases/download/v$env:MPV_VERSION/mpv-v$env:MPV_VERSION-x86_64-pc-windows-msvc.zip"
+          $work = Join-Path $env:RUNNER_TEMP 'mpv'
+          New-Item -ItemType Directory -Force -Path $work | Out-Null
+          $zip = Join-Path $work 'mpv.zip'
+          Write-Host "Downloading $url"
+          Invoke-WebRequest -Uri $url -OutFile $zip
+          Expand-Archive -Path $zip -DestinationPath $work -Force
+          $mpvExe = Get-ChildItem -Path $work -Filter 'mpv.exe' -Recurse | Select-Object -First 1
+          if (-not $mpvExe) { throw "mpv.exe not found in zip" }
+          New-Item -ItemType Directory -Force -Path 'src-tauri/binaries' | Out-Null
+          Copy-Item $mpvExe.FullName 'src-tauri/binaries/mpv-x86_64-pc-windows-msvc.exe' -Force
+          Write-Host "Sidecar placed:"
+          Get-Item 'src-tauri/binaries/mpv-x86_64-pc-windows-msvc.exe' | Select-Object FullName, Length
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build + sign Tauri bundles
+        uses: tauri-apps/tauri-action@v0
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        with:
+          args: ''
+
+      - name: Locate updater artifact + emit platform fragment
+        id: find
+        shell: bash
+        env:
+          PLATFORM: ${{ matrix.platform }}
+          BUNDLE_GLOB: ${{ matrix.bundle_glob }}
+          RELEASES_REPO: henningcullin/rustflix-releases
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          bundle_root="src-tauri/target/release/bundle"
+
+          echo "::group::Diagnostics"
+          echo "PWD: $(pwd)"
+          echo "bundle_root: $bundle_root"
+          if [ -d "$bundle_root" ]; then
+            find "$bundle_root" -maxdepth 6 -mindepth 1 -printf "%y  %p\n" || true
+          else
+            echo "bundle_root missing"
+          fi
+          echo "::endgroup::"
+
+          if [ ! -d "$bundle_root" ]; then
+            echo "Bundle root '$bundle_root' missing after build" >&2
+            exit 1
+          fi
+
+          mapfile -t bundles < <(find "$bundle_root" -type f -name "$BUNDLE_GLOB")
+          if [ ${#bundles[@]} -eq 0 ]; then
+            echo "No bundle matching '$BUNDLE_GLOB' under $bundle_root" >&2
+            exit 1
+          fi
+          bundle_path="${bundles[0]}"
+          sig_path="${bundle_path}.sig"
+          if [ ! -f "$sig_path" ]; then
+            echo "Missing signature file: $sig_path" >&2
+            exit 1
+          fi
+
+          bundle_name="$(basename "$bundle_path")"
+          # GitHub normalises release asset filenames by replacing spaces with
+          # periods at upload time.
+          asset_name="${bundle_name// /.}"
+          url="https://github.com/${RELEASES_REPO}/releases/download/${TAG}/${asset_name}"
+          signature="$(tr -d '\r\n' < "$sig_path")"
+
+          mkdir -p artifacts
+          staged_bundle="artifacts/${asset_name}"
+          staged_sig="artifacts/${asset_name}.sig"
+          cp "$bundle_path" "$staged_bundle"
+          cp "$sig_path" "$staged_sig"
+
+          fragment="artifacts/${PLATFORM}.json"
+          jq -n \
+            --arg platform "${PLATFORM}" \
+            --arg signature "${signature}" \
+            --arg url "${url}" \
+            --arg bundle_asset "${asset_name}" \
+            --arg sig_asset "${asset_name}.sig" \
+            '{platform: $platform, signature: $signature, url: $url, bundle_asset: $bundle_asset, sig_asset: $sig_asset}' \
+            > "$fragment"
+
+          echo "Staged:"
+          ls -la artifacts
+
+      - name: Upload platform artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: rustflix-${{ matrix.platform }}
+          path: artifacts/*
+          if-no-files-found: error
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all platform artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: staged
+          pattern: rustflix-*
+          merge-multiple: true
+
+      - name: Build unified latest.json
+        id: manifest
+        shell: bash
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          ls -la staged
+
+          version="${TAG#v}"
+          pub_date="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+          platforms_json="{}"
+          for fragment in staged/*.json; do
+            platform="$(jq -r .platform "$fragment")"
+            signature="$(jq -r .signature "$fragment")"
+            url="$(jq -r .url "$fragment")"
+            entry="$(jq -n --arg sig "$signature" --arg url "$url" \
+              '{signature: $sig, url: $url}')"
+            platforms_json="$(jq --arg key "$platform" --argjson val "$entry" \
+              '. + {($key): $val}' <<< "$platforms_json")"
+          done
+
+          jq -n \
+            --arg version "$version" \
+            --arg pub_date "$pub_date" \
+            --argjson platforms "$platforms_json" \
+            '{version: $version, pub_date: $pub_date, platforms: $platforms}' \
+            > latest.json
+
+          echo "::group::latest.json"
+          cat latest.json
+          echo "::endgroup::"
+
+      - name: Publish release to releases repo
+        env:
+          GH_TOKEN: ${{ secrets.RELEASES_REPO_TOKEN }}
+          RELEASES_REPO: henningcullin/rustflix-releases
+          TAG: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t assets < <(find staged -maxdepth 1 -type f ! -name '*.json')
+          gh release create "$TAG" \
+            "${assets[@]}" \
+            latest.json \
+            --repo "$RELEASES_REPO" \
+            --title "$TAG" \
+            --notes "Automated release."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,121 @@
+# Coding Ground Rules
+
+These rules apply to all code in this project. The project is primarily JavaScript/TypeScript, but the principles below apply across every language used here.
+
+## Control flow syntax
+
+- Always write `if () { ... }` and `for () { ... }` with a body block.
+- Never write `if ();` or `for ();` — an empty statement after the condition is forbidden.
+- Always use a block for control flow constructs (`if`, `else`, `for`, `while`, `do`), even when the body is a single statement or a one-line `return`.
+
+```ts
+// Good
+if (user.isActive) {
+    return user;
+}
+
+for (const item of items) {
+    process(item);
+}
+
+// Bad
+if (user.isActive) return user;
+
+for (const item of items) process(item);
+
+if (user.isActive);   // never
+for (let i = 0; i < n; i++);   // never
+```
+
+## Ternaries
+
+- Avoid all nested ternaries. If a condition needs more than one ternary to express, use `if`/`else` statements or extract a small function instead.
+
+```ts
+// Good
+function describe(status) {
+    if (status === "open") {
+        return "Open";
+    }
+
+    if (status === "pending") {
+        return "Pending";
+    }
+
+    return "Closed";
+}
+
+// Bad
+const label = status === "open" ? "Open" : status === "pending" ? "Pending" : "Closed";
+```
+
+A single, simple ternary is fine when it improves readability.
+
+## Paradigm
+
+- Prefer a functional style where it fits: pure functions, immutability, mapping/filtering/reducing over data, avoiding hidden side effects.
+- Do not force functional style when another paradigm fits better. Use whichever paradigm — functional, imperative, or object-oriented — produces the most maintainable and scalable solution for the problem at hand.
+- The goal is maintainable, scalable code. Paradigm is a tool, not a rule.
+
+## Naming
+
+- Use complete, descriptive names. A reader should understand the name without context.
+- Do not use cryptic abbreviations.
+    - Write `error`, not `e`.
+    - Write `event`, not `e`.
+    - Write `button`, not `btn`.
+    - Write `request`, not `req`. Write `response`, not `res`.
+    - Write `index`, not `idx`. Write `element`, not `el`.
+- Do not go to the opposite extreme. Names should be complete, not verbose for its own sake. `userAuthenticationServiceFactoryConfigurationOptions` is worse than `authConfig` when the surrounding code already makes the meaning clear.
+- Well-known, conventional short names are acceptable in their normal scope: loop counters `i`, `j`, mathematical `x`, `y`, callback parameters that mirror standard signatures.
+
+## Spacing and readability
+
+- Add blank lines between logical groups of statements to make code easier to scan.
+- Separate variable declarations, control flow blocks, and the final `return` from each other when it aids reading.
+- Inside functions, group related statements together and put a blank line between groups.
+
+```ts
+// Good
+function checkout(cart, user) {
+    const items = cart.items;
+    const total = sumPrices(items);
+
+    if (total <= 0) {
+        throw new Error("Cart is empty");
+    }
+
+    const order = createOrder(user, items, total);
+    persist(order);
+
+    return order;
+}
+```
+
+Don't insert blank lines so aggressively that every other line is empty — the goal is readability, not visual padding.
+
+## Branch naming
+
+- All work branches follow the schema `fix/N-slug`, where `N` is an incrementing integer and `slug` is a short kebab-case description (3–5 words).
+- Determine the next `N` by inspecting existing branches: `git branch -a --list 'origin/fix/*' 'fix/*'` and taking `max(N) + 1`. Numbers are global across the repo and never reused, even if a branch was deleted or its PR was closed without merging.
+- One branch = one PR = one logical change. Don't pile unrelated work onto the same branch.
+- This applies to every branch we create, not just iterate runs.
+
+Examples:
+
+```
+fix/58-backup-delete-confirm-overflow
+fix/59-document-branch-naming
+fix/60-restart-policy-toggle
+```
+
+## Summary
+
+Code in this project should be:
+
+- Always block-bodied for control flow.
+- Free of nested ternaries.
+- Written in whichever paradigm best serves maintainability and scale, with a functional lean where natural.
+- Named with complete, descriptive identifiers — never cryptic, never excessive.
+- Spaced for readability.
+- Placed on branches named `fix/N-slug` with a single logical change per branch.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,78 @@
-# Tauri + SvelteKit + TypeScript
+# Rustflix
 
-This template should help get you started developing with Tauri, SvelteKit and TypeScript in Vite.
+A Netflix-style local-library media app. Point it at folders of movies and series
+on your disk; Rustflix indexes them, tracks watched progress, and plays them
+through a bundled `mpv`.
 
-## Recommended IDE Setup
+Built with Tauri 2, SvelteKit (Svelte 5 runes), Tailwind, and `sqlx` over SQLite.
 
-[VS Code](https://code.visualstudio.com/) + [Svelte](https://marketplace.visualstudio.com/items?itemName=svelte.svelte-vscode) + [Tauri](https://marketplace.visualstudio.com/items?itemName=tauri-apps.tauri-vscode) + [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer).
+## Requirements
+
+- **Node.js** 20+
+- **Rust** stable, MSVC toolchain on Windows (`rustup default stable-x86_64-pc-windows-msvc`)
+- **Microsoft C++ Build Tools** ("Desktop development with C++" workload) on Windows
+- **WebView2** runtime (preinstalled on modern Windows)
+- **mpv binary** — see _Bundling mpv_ below; only needed once at build time
+
+## Run / build
+
+```sh
+pnpm install
+pnpm tauri:dev         # dev (hot reload)
+pnpm tauri:build       # release installer
+```
+
+## Bundling mpv
+
+Rustflix ships `mpv` as a Tauri sidecar so end users don't need to install it.
+You drop the binary into `src-tauri/binaries/` once; Tauri then bakes it into the
+installer.
+
+The expected name encodes the target triple, e.g. on Windows x86_64:
+
+```
+src-tauri/binaries/mpv-x86_64-pc-windows-msvc.exe
+```
+
+Either run the helper script:
+
+```powershell
+pwsh ./scripts/fetch-mpv.ps1
+```
+
+…or follow the manual instructions in `src-tauri/binaries/README.md`.
+
+## Releases
+
+Releases are tag-driven. `pnpm release patch` (or `release:ps` on Windows) bumps
+the version across `package.json` + `Cargo.toml` + `tauri.conf.json`,
+regenerates `Cargo.lock`, sanity-checks both builds, commits, tags, and pushes.
+The `.github/workflows/release.yml` workflow then builds, signs with the
+updater key, and publishes installers + `latest.json` to a separate
+`henningcullin/rustflix-releases` repo.
+
+First-time setup (generates the signing key, creates the releases repo, sets
+GitHub Actions secrets) is in `scripts/SETUP-UPDATER.md`.
+
+## Conventions
+
+- Coding rules: `CLAUDE.md`
+- Branch / PR / merge workflow for iterating on a list of changes:
+  `.claude/commands/iterate.md` (invoke with `/iterate`)
+- PR template: `.github/pull_request_template.md`
+
+## Project layout
+
+```
+src/                       SvelteKit frontend
+  lib/api.ts               Typed wrapper around invoke()
+  lib/components/          Hero, MediaRow, PosterCard, TopNav
+  routes/                  Home, /films, /series, settings
+src-tauri/
+  src/                     Rust backend (commands, queries, scanner, player)
+  migrations/              sqlx schema (applied at startup)
+  binaries/                mpv sidecar lives here
+scripts/                   Build-time + release helpers
+.github/workflows/         CI/CD (release.yml)
+.claude/commands/          Project slash commands (/iterate)
+```

--- a/scripts/SETUP-UPDATER.md
+++ b/scripts/SETUP-UPDATER.md
@@ -1,0 +1,49 @@
+# Updater setup
+
+One-time setup for the Tauri auto-updater. Two equivalent scripts ship — pick whichever matches where your `gh` CLI lives:
+
+**WSL / Linux / macOS:**
+```bash
+bash scripts/setup-updater.sh
+```
+
+**Windows PowerShell:**
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/setup-updater.ps1
+```
+
+## What it does
+
+1. Verifies `gh` (GitHub CLI) and `pnpm` are installed.
+2. Authenticates `gh` if needed.
+3. Generates an Ed25519 signing keypair at `~/.tauri/rustflix.key` (+ `.pub`).
+4. Creates the public `henningcullin/rustflix-releases` repo (skipped if it already exists).
+5. Walks you through creating a fine-grained PAT scoped to that repo.
+6. Sets three Actions secrets on the source repo:
+   - `TAURI_SIGNING_PRIVATE_KEY`
+   - `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`
+   - `RELEASES_REPO_TOKEN`
+7. Prints the public key — paste it into `src-tauri/tauri.conf.json` under `plugins.updater.pubkey`.
+
+## After running
+
+- Replace the `REPLACE_WITH_OUTPUT_OF_setup-updater` placeholder in `tauri.conf.json` with the printed pubkey, commit, push.
+- Back up `~/.tauri/rustflix.key` to a password manager. Losing it means losing the ability to ship updates to existing installs forever.
+
+## Releasing
+
+Every release after setup runs through one command:
+
+**WSL / Linux / macOS:**
+```bash
+pnpm release patch       # or minor / major / 0.2.0
+```
+
+**Windows PowerShell:**
+```powershell
+pnpm release:ps patch    # or minor / major / 0.2.0
+```
+
+The script bumps `package.json` + `src-tauri/Cargo.toml` + `src-tauri/tauri.conf.json` in lockstep, regenerates `Cargo.lock`, runs `pnpm check` + `cargo check`, makes a single `vX.Y.Z` commit on master, tags it, and pushes both. See `scripts/release.sh` for the source of truth.
+
+The Release workflow then runs the build matrix (currently Windows only — uncomment the macOS/Linux blocks in `.github/workflows/release.yml` to expand), signs each bundle with the same key, and uploads them alongside a unified `latest.json` whose `platforms` map carries one entry per OS. The app picks up the new version on next launch via `tauri-plugin-updater`.

--- a/scripts/fetch-mpv.ps1
+++ b/scripts/fetch-mpv.ps1
@@ -1,0 +1,84 @@
+#!/usr/bin/env pwsh
+#
+# Fetches an mpv binary into src-tauri/binaries/ with the correct
+# target-triple suffix so Tauri can bundle it as a sidecar.
+#
+# Strategy (in order):
+#   1. If mpv.exe already exists on PATH, copy it.
+#   2. Else, run `winget install mpv` and copy from a winget install dir.
+#
+# Run from anywhere; paths resolve relative to the repo root.
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+$binDir = Join-Path $repoRoot "src-tauri/binaries"
+$targetTriple = "x86_64-pc-windows-msvc"
+$destName = "mpv-$targetTriple.exe"
+$dest = Join-Path $binDir $destName
+
+if (-not (Test-Path $binDir)) {
+    New-Item -ItemType Directory -Force -Path $binDir | Out-Null
+}
+
+function Copy-Mpv($source) {
+    Write-Host "Copying $source -> $dest"
+    Copy-Item -Force $source $dest
+    Write-Host "Done. Sidecar at $dest"
+}
+
+# Step 1: existing mpv on PATH
+$existing = Get-Command mpv -ErrorAction SilentlyContinue
+if ($existing) {
+    Copy-Mpv $existing.Source
+    exit 0
+}
+
+# Step 2: try winget
+$winget = Get-Command winget -ErrorAction SilentlyContinue
+if (-not $winget) {
+    Write-Error @"
+No mpv.exe on PATH and winget is not available.
+Download mpv manually from https://mpv.io/installation/ and place mpv.exe at:
+  $dest
+"@
+    exit 1
+}
+
+Write-Host "Installing mpv via winget…"
+# Prefer the official MSVC CI build — it's a per-user zip install (no UAC).
+# Fall back to the shinchiro community installer, which triggers UAC because
+# it writes to Program Files.
+& winget install --id=mpv-player.mpv-CI.MSVC -e --silent --accept-source-agreements --accept-package-agreements
+if ($LASTEXITCODE -ne 0) {
+    & winget install --id=shinchiro.mpv -e --silent --accept-source-agreements --accept-package-agreements
+}
+
+# Re-resolve after install
+$existing = Get-Command mpv -ErrorAction SilentlyContinue
+if ($existing) {
+    Copy-Mpv $existing.Source
+    exit 0
+}
+
+# Last-ditch: look in common install dirs (PATH may not be refreshed in this session)
+$candidates = @(
+    "$env:LOCALAPPDATA\Microsoft\WinGet\Packages\mpv-player.mpv-CI.MSVC_*\mpv.exe",
+    "$env:LOCALAPPDATA\Microsoft\WinGet\Packages\shinchiro.mpv_*\mpv\mpv.exe",
+    "$env:LOCALAPPDATA\Programs\mpv\mpv.exe",
+    "C:\Program Files\mpv\mpv.exe",
+    "C:\Program Files (x86)\mpv\mpv.exe"
+)
+foreach ($pattern in $candidates) {
+    $found = Get-Item $pattern -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($found) {
+        Copy-Mpv $found.FullName
+        exit 0
+    }
+}
+
+Write-Error @"
+Installed mpv but couldn't locate mpv.exe. Find it manually and copy it to:
+  $dest
+"@
+exit 1

--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -1,0 +1,246 @@
+# One-command release on Windows. See scripts/release.sh for the bash
+# equivalent — this script mirrors it step-for-step so behaviour stays
+# in lockstep across the OS split. Usage:
+#   .\scripts\release.ps1 patch
+#   .\scripts\release.ps1 minor
+#   .\scripts\release.ps1 major
+#   .\scripts\release.ps1 0.2.0          (explicit, leading "v" optional)
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [string]$Target
+)
+
+$ErrorActionPreference = 'Stop'
+
+# All text rewrites below go through this encoding so output files don't
+# get a UTF-8 BOM and don't get CRLF endings on Windows. The repo's
+# .gitattributes file already locks Cargo.lock + .json + .toml to LF,
+# but writing them correctly on first pass avoids a noisy `git status`
+# in between the script's steps.
+$Utf8NoBom = New-Object System.Text.UTF8Encoding $false
+
+function Write-LfText {
+    param(
+        [string]$Path,
+        [string]$Content
+    )
+    $normalized = $Content -replace "`r`n", "`n"
+    [System.IO.File]::WriteAllText($Path, $normalized, $Utf8NoBom)
+}
+
+function Show-Usage {
+    Write-Host @'
+Usage: .\scripts\release.ps1 patch|minor|major|<version>
+  patch         bumps Z in X.Y.Z
+  minor         bumps Y and zeroes Z
+  major         bumps X and zeroes Y + Z
+  <version>     explicit semver (e.g. 0.2.0 or v0.2.0-rc.1)
+'@
+    exit 64
+}
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+Set-Location $repoRoot
+
+$packageJson = 'package.json'
+$cargoToml = 'src-tauri/Cargo.toml'
+$tauriConf = 'src-tauri/tauri.conf.json'
+
+function Require-CleanTree {
+    $status = git status --porcelain
+    if ($status) {
+        Write-Error "working tree is not clean; commit or stash first`n$status"
+    }
+}
+
+function Require-OnMaster {
+    $branch = (git rev-parse --abbrev-ref HEAD).Trim()
+    if ($branch -ne 'master') {
+        Write-Error "must be on master to release, currently on '$branch'"
+    }
+}
+
+function Require-UpToDate {
+    git fetch --quiet origin master | Out-Null
+    $localSha = (git rev-parse '@').Trim()
+    $remoteSha = (git rev-parse 'origin/master').Trim()
+    if ($localSha -ne $remoteSha) {
+        Write-Error "local master diverges from origin/master; sync first`n  local:  $localSha`n  remote: $remoteSha"
+    }
+}
+
+function Get-CurrentVersion {
+    $pkg = (Get-Content $packageJson -Raw | ConvertFrom-Json).version
+    $tauri = (Get-Content $tauriConf -Raw | ConvertFrom-Json).version
+
+    $cargoLine = Select-String -Path $cargoToml -Pattern '^version = "([^"]+)"' | Select-Object -First 1
+    if (-not $cargoLine) {
+        Write-Error "could not find a version line in $cargoToml"
+    }
+    $cargo = $cargoLine.Matches[0].Groups[1].Value
+
+    if ($pkg -ne $cargo -or $pkg -ne $tauri) {
+        Write-Error "versions drifted between manifests:`n  $packageJson`t$pkg`n  $cargoToml`t$cargo`n  $tauriConf`t$tauri"
+    }
+    return $pkg
+}
+
+function Bump-Part {
+    param(
+        [string]$Current,
+        [string]$Part
+    )
+    if ($Current -notmatch '^(\d+)\.(\d+)\.(\d+)') {
+        Write-Error "current version '$Current' is not semver-shaped"
+    }
+    [int]$majorPart = $Matches[1]
+    [int]$minorPart = $Matches[2]
+    [int]$patchPart = $Matches[3]
+
+    switch ($Part) {
+        'patch' { $patchPart++ }
+        'minor' { $minorPart++; $patchPart = 0 }
+        'major' { $majorPart++; $minorPart = 0; $patchPart = 0 }
+        default { Write-Error "unknown bump '$Part'" }
+    }
+    return "$majorPart.$minorPart.$patchPart"
+}
+
+function Resolve-Target {
+    param([string]$Arg)
+    switch -Regex ($Arg) {
+        '^(patch|minor|major)$' { return (Bump-Part -Current (Get-CurrentVersion) -Part $Arg) }
+        '^[vV](.+)$' { return $Matches[1] }
+        '^\d+\.\d+\.\d+([.-].+)?$' { return $Arg }
+        default { Show-Usage }
+    }
+}
+
+function Rewrite-JsonVersion {
+    param(
+        [string]$Path,
+        [string]$NextVersion
+    )
+    # Delegate to node — Windows PowerShell 5.1's ConvertFrom-Json doesn't
+    # preserve key order (it materializes to a PSCustomObject whose
+    # properties end up alphabetized), which on the first run rewrote
+    # package.json with every key in a new spot and produced a 100-line
+    # diff for a one-line version bump. node's JSON.parse preserves
+    # insertion order, matching the bash twin exactly.
+    # Slice the last two args off process.argv regardless of node's
+    # version-dependent layout for `-e`. Pre-Node-20 put '[eval]' at
+    # argv[1] and user args at argv[2]+; Node 22 dropped the placeholder
+    # and user args start at argv[1]. Pulling from the end sidesteps
+    # both.
+    $script = @"
+const fs = require('fs');
+const [path, next] = process.argv.slice(-2);
+const obj = JSON.parse(fs.readFileSync(path, 'utf8'));
+obj.version = next;
+fs.writeFileSync(path, JSON.stringify(obj, null, 2) + '\n');
+"@
+    node -e $script $Path $NextVersion
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "node JSON rewrite failed for $Path"
+    }
+}
+
+function Rewrite-CargoToml {
+    param([string]$NextVersion)
+    $lines = Get-Content $cargoToml
+    $done = $false
+    $rewritten = $lines | ForEach-Object {
+        if (-not $done -and $_ -match '^version = "') {
+            $done = $true
+            "version = `"$NextVersion`""
+        } else {
+            $_
+        }
+    }
+    Write-LfText -Path $cargoToml -Content (($rewritten -join "`n") + "`n")
+}
+
+function Normalize-Lf {
+    param([string]$Path)
+    $bytes = [System.IO.File]::ReadAllBytes($Path)
+    if ($bytes.Length -eq 0) { return }
+    $text = [System.Text.Encoding]::UTF8.GetString($bytes)
+    Write-LfText -Path $Path -Content $text
+}
+
+function Regen-CargoLock {
+    Push-Location 'src-tauri'
+    try {
+        cargo update --workspace --quiet
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "cargo update failed"
+        }
+    } finally {
+        Pop-Location
+    }
+    # cargo on Windows writes Cargo.lock with native CRLF terminators
+    # even when the repo's .gitattributes says eol=lf — the smudge
+    # filter only kicks in on `git checkout`, not on tool writes.
+    # Normalize back to LF in-place so the diff stays small.
+    Normalize-Lf -Path 'src-tauri/Cargo.lock'
+}
+
+function Run-Checks {
+    Write-Host '==> pnpm check'
+    pnpm check
+    if ($LASTEXITCODE -ne 0) { Write-Error "pnpm check failed" }
+
+    Write-Host '==> cargo check (Tauri)'
+    Push-Location 'src-tauri'
+    try {
+        cargo check --quiet
+        if ($LASTEXITCODE -ne 0) { Write-Error "cargo check failed" }
+    } finally {
+        Pop-Location
+    }
+}
+
+$current = Get-CurrentVersion
+$target = Resolve-Target $Target
+$tag = "v$target"
+
+if ($target -eq $current) {
+    Write-Error "target version ($target) equals current ($current); nothing to bump"
+}
+
+Require-CleanTree
+Require-OnMaster
+Require-UpToDate
+
+$existingTag = git rev-parse --verify --quiet "refs/tags/$tag" 2>$null
+if ($LASTEXITCODE -eq 0 -and $existingTag) {
+    Write-Error "tag $tag already exists locally"
+}
+
+Write-Host "Bumping $current -> $target"
+
+Rewrite-JsonVersion -Path $packageJson -NextVersion $target
+Rewrite-JsonVersion -Path $tauriConf -NextVersion $target
+Rewrite-CargoToml -NextVersion $target
+Regen-CargoLock
+
+Run-Checks
+
+git add $packageJson $cargoToml $tauriConf 'src-tauri/Cargo.lock'
+git commit -m $tag
+if ($LASTEXITCODE -ne 0) { Write-Error "git commit failed" }
+
+git tag $tag
+if ($LASTEXITCODE -ne 0) { Write-Error "git tag failed" }
+
+Write-Host "==> pushing master + tag $tag"
+git push origin master
+if ($LASTEXITCODE -ne 0) { Write-Error "git push master failed" }
+git push origin $tag
+if ($LASTEXITCODE -ne 0) { Write-Error "git push tag failed" }
+
+Write-Host ''
+Write-Host "Released $tag."
+Write-Host 'The Release workflow will pick up the tag and build the bundles.'

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# One-command release: bump version in package.json + Cargo.toml +
+# tauri.conf.json, regenerate Cargo.lock, sanity-check builds, commit,
+# tag, push. Usage:
+#   scripts/release.sh patch
+#   scripts/release.sh minor
+#   scripts/release.sh major
+#   scripts/release.sh 0.2.0          (explicit, leading "v" optional)
+#
+# Assumes master is the release branch and the working tree is clean.
+
+set -euo pipefail
+
+usage() {
+    cat >&2 <<EOF
+Usage: $0 patch|minor|major|<version>
+  patch         bumps Z in X.Y.Z
+  minor         bumps Y and zeroes Z
+  major         bumps X and zeroes Y + Z
+  <version>     explicit semver (e.g. 0.2.0 or v0.2.0-rc.1)
+EOF
+    exit 64
+}
+
+[ $# -eq 1 ] || usage
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+package_json="package.json"
+cargo_toml="src-tauri/Cargo.toml"
+tauri_conf="src-tauri/tauri.conf.json"
+
+require_clean_tree() {
+    if [ -n "$(git status --porcelain)" ]; then
+        echo "ERROR: working tree is not clean; commit or stash first" >&2
+        git status --short >&2
+        exit 1
+    fi
+}
+
+require_on_master() {
+    local branch
+    branch="$(git rev-parse --abbrev-ref HEAD)"
+    if [ "$branch" != "master" ]; then
+        echo "ERROR: must be on master to release, currently on '$branch'" >&2
+        exit 1
+    fi
+}
+
+require_up_to_date() {
+    git fetch --quiet origin master
+    local local_sha remote_sha
+    local_sha="$(git rev-parse @)"
+    remote_sha="$(git rev-parse @{u} 2>/dev/null || git rev-parse origin/master)"
+    if [ "$local_sha" != "$remote_sha" ]; then
+        echo "ERROR: local master diverges from origin/master; sync first" >&2
+        echo "  local:  $local_sha" >&2
+        echo "  remote: $remote_sha" >&2
+        exit 1
+    fi
+}
+
+current_version() {
+    # Read directly from package.json (it's the source of truth for what
+    # the panel ships as). The three files must already be in lockstep
+    # going in — if they aren't, abort rather than silently picking one.
+    local pkg cargo tauri
+    pkg="$(node -p "require('./$package_json').version")"
+    cargo="$(grep -m1 -E '^version = ' "$cargo_toml" | sed -E 's/^version = "(.*)"$/\1/')"
+    tauri="$(node -p "require('./$tauri_conf').version")"
+    if [ "$pkg" != "$cargo" ] || [ "$pkg" != "$tauri" ]; then
+        echo "ERROR: versions drifted between manifests" >&2
+        printf '  %-30s %s\n' "$package_json" "$pkg" >&2
+        printf '  %-30s %s\n' "$cargo_toml" "$cargo" >&2
+        printf '  %-30s %s\n' "$tauri_conf" "$tauri" >&2
+        exit 1
+    fi
+    echo "$pkg"
+}
+
+bump_part() {
+    local current="$1"
+    local part="$2"
+    local core
+    core="$(echo "$current" | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+).*/\1/')"
+    local major minor patch
+    IFS=. read -r major minor patch <<< "$core"
+    case "$part" in
+        patch) patch=$((patch + 1)) ;;
+        minor) minor=$((minor + 1)); patch=0 ;;
+        major) major=$((major + 1)); minor=0; patch=0 ;;
+        *) echo "ERROR: unknown bump '$part'" >&2; exit 64 ;;
+    esac
+    echo "$major.$minor.$patch"
+}
+
+resolve_target() {
+    local arg="$1"
+    case "$arg" in
+        patch|minor|major)
+            bump_part "$(current_version)" "$arg"
+            ;;
+        v*|V*)
+            echo "${arg#[vV]}"
+            ;;
+        *)
+            # Treat any other arg as an explicit version literal; validate shape.
+            if [[ ! "$arg" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-].+)?$ ]]; then
+                echo "ERROR: '$arg' is not a recognised version" >&2
+                usage
+            fi
+            echo "$arg"
+            ;;
+    esac
+}
+
+rewrite_package_json() {
+    local next="$1"
+    node -e "
+        const fs = require('fs');
+        const path = '$package_json';
+        const pkg = JSON.parse(fs.readFileSync(path, 'utf8'));
+        pkg.version = '$next';
+        fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + '\n');
+    "
+}
+
+rewrite_tauri_conf() {
+    local next="$1"
+    node -e "
+        const fs = require('fs');
+        const path = '$tauri_conf';
+        const conf = JSON.parse(fs.readFileSync(path, 'utf8'));
+        conf.version = '$next';
+        fs.writeFileSync(path, JSON.stringify(conf, null, 2) + '\n');
+    "
+}
+
+rewrite_cargo_toml() {
+    local next="$1"
+    # Restrict the rewrite to the [package] block's first `version =` so a
+    # `version = "..."` line in a `[dependencies]` entry can never be hit.
+    # GNU sed and BSD sed both accept `0,/.../{ s/old/new/ }` for "first
+    # match only", so this works on Linux and macOS without `sed -i`.
+    local tmp
+    tmp="$(mktemp)"
+    awk -v next="$next" '
+        BEGIN { done = 0 }
+        /^version = "/ && !done { print "version = \"" next "\""; done = 1; next }
+        { print }
+    ' "$cargo_toml" > "$tmp"
+    mv "$tmp" "$cargo_toml"
+}
+
+regen_cargo_lock() {
+    # Rewriting Cargo.toml drops the package version out of sync with the
+    # lock. `cargo update --workspace` keeps Cargo.lock authoritative
+    # without bumping any third-party deps.
+    (cd src-tauri && cargo update --workspace --quiet)
+}
+
+run_checks() {
+    echo "==> pnpm check"
+    pnpm check
+    echo "==> cargo check (Tauri)"
+    (cd src-tauri && cargo check --quiet)
+}
+
+current="$(current_version)"
+target="$(resolve_target "$1")"
+tag="v$target"
+
+if [ "$target" = "$current" ]; then
+    echo "ERROR: target version ($target) equals current ($current); nothing to bump" >&2
+    exit 1
+fi
+
+require_clean_tree
+require_on_master
+require_up_to_date
+
+if git rev-parse --verify --quiet "refs/tags/$tag" >/dev/null; then
+    echo "ERROR: tag $tag already exists locally" >&2
+    exit 1
+fi
+
+echo "Bumping $current -> $target"
+
+rewrite_package_json "$target"
+rewrite_tauri_conf "$target"
+rewrite_cargo_toml "$target"
+regen_cargo_lock
+
+run_checks
+
+git add "$package_json" "$cargo_toml" "$tauri_conf" "src-tauri/Cargo.lock"
+git commit -m "$tag"
+git tag "$tag"
+
+echo "==> pushing master + tag $tag"
+git push origin master
+git push origin "$tag"
+
+echo
+echo "Released $tag."
+echo "The Release workflow will pick up the tag and build the bundles."

--- a/scripts/setup-updater.ps1
+++ b/scripts/setup-updater.ps1
@@ -1,0 +1,90 @@
+$ErrorActionPreference = 'Stop'
+
+$SourceRepo = 'henningcullin/rustflix'
+$ReleasesRepo = 'henningcullin/rustflix-releases'
+$KeyPath = Join-Path $env:USERPROFILE '.tauri/rustflix.key'
+
+function Require-Tool($name, $hint) {
+    if (-not (Get-Command $name -ErrorAction SilentlyContinue)) {
+        Write-Error "Missing required tool: $name. $hint"
+    }
+}
+
+Write-Host '== Tauri updater setup ==' -ForegroundColor Cyan
+
+Require-Tool 'gh' 'Install GitHub CLI: https://cli.github.com/'
+Require-Tool 'pnpm' 'Install pnpm: https://pnpm.io/installation'
+
+# gh auth
+gh auth status 2>&1 | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    Write-Host 'gh CLI is not authenticated. Running `gh auth login`...' -ForegroundColor Yellow
+    gh auth login
+}
+
+# Generate (or reuse) the signing keypair
+if (Test-Path $KeyPath) {
+    Write-Host "Signing key already exists at $KeyPath - reusing." -ForegroundColor Green
+} else {
+    Write-Host "Generating signing key at $KeyPath ..." -ForegroundColor Cyan
+    $keyDir = Split-Path $KeyPath -Parent
+    if (-not (Test-Path $keyDir)) {
+        New-Item -ItemType Directory -Path $keyDir -Force | Out-Null
+    }
+    pnpm tauri signer generate -w $KeyPath
+}
+
+$privateKey = Get-Content $KeyPath -Raw
+$publicKey  = Get-Content "$KeyPath.pub" -Raw
+
+# Capture the password set during key generation
+$password = Read-Host 'Enter the password you set on the signing key (empty if none)' -AsSecureString
+$plainPassword = [System.Net.NetworkCredential]::new('', $password).Password
+
+# Create the public releases repo if it does not yet exist
+$repoExists = $false
+gh repo view $ReleasesRepo --json name 2>$null | Out-Null
+if ($LASTEXITCODE -eq 0) {
+    $repoExists = $true
+}
+
+if (-not $repoExists) {
+    Write-Host "Creating public repo $ReleasesRepo ..." -ForegroundColor Cyan
+    gh repo create $ReleasesRepo --public --description 'Public release artifacts for rustflix (do not push code here)'
+} else {
+    Write-Host "Releases repo $ReleasesRepo already exists - skipping create." -ForegroundColor Green
+}
+
+# Fine-grained PAT for the releases repo
+Write-Host ''
+Write-Host '== Create a fine-grained Personal Access Token ==' -ForegroundColor Cyan
+Write-Host 'Open: https://github.com/settings/personal-access-tokens/new'
+Write-Host '  - Resource owner: henningcullin'
+Write-Host "  - Repository access: Only select repositories -> $ReleasesRepo"
+Write-Host '  - Permissions -> Repository permissions -> Contents: Read and write'
+Write-Host '  - Expiration: 1 year (or custom)'
+Write-Host ''
+$pat = Read-Host 'Paste the generated token' -AsSecureString
+$plainPat = [System.Net.NetworkCredential]::new('', $pat).Password
+
+# Set Actions secrets on the source repo
+Write-Host 'Setting Actions secrets on the source repo ...' -ForegroundColor Cyan
+$plainPrivate = $privateKey.Trim()
+$plainPublic  = $publicKey.Trim()
+
+$plainPrivate     | gh secret set TAURI_SIGNING_PRIVATE_KEY          --repo $SourceRepo
+$plainPassword    | gh secret set TAURI_SIGNING_PRIVATE_KEY_PASSWORD --repo $SourceRepo
+$plainPat         | gh secret set RELEASES_REPO_TOKEN                --repo $SourceRepo
+
+Write-Host ''
+Write-Host '== Done ==' -ForegroundColor Green
+Write-Host ''
+Write-Host 'Next steps (manual):' -ForegroundColor Cyan
+Write-Host '  1. Open src-tauri/tauri.conf.json'
+Write-Host '  2. Replace REPLACE_WITH_OUTPUT_OF_setup-updater with:'
+Write-Host ''
+Write-Host $plainPublic -ForegroundColor Yellow
+Write-Host ''
+Write-Host '  3. Commit + push.'
+Write-Host "  4. Back up $KeyPath somewhere safe (password manager). If you"
+Write-Host '     lose it, you can never ship updates to existing installs.'

--- a/scripts/setup-updater.sh
+++ b/scripts/setup-updater.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SOURCE_REPO="henningcullin/rustflix"
+RELEASES_REPO="henningcullin/rustflix-releases"
+KEY_PATH="$HOME/.tauri/rustflix.key"
+
+require_tool() {
+    local name="$1"
+    local hint="$2"
+    if ! command -v "$name" >/dev/null 2>&1; then
+        echo "ERROR: Missing required tool: $name. $hint" >&2
+        exit 1
+    fi
+}
+
+printf '\033[36m== Tauri updater setup ==\033[0m\n'
+
+require_tool gh   'Install GitHub CLI: https://cli.github.com/'
+require_tool pnpm 'Install pnpm: https://pnpm.io/installation'
+
+# gh auth
+if ! gh auth status >/dev/null 2>&1; then
+    printf '\033[33mgh CLI is not authenticated. Running `gh auth login`...\033[0m\n'
+    gh auth login
+fi
+
+# Generate (or reuse) the signing keypair
+if [[ -f "$KEY_PATH" ]]; then
+    printf '\033[32mSigning key already exists at %s - reusing.\033[0m\n' "$KEY_PATH"
+else
+    printf '\033[36mGenerating signing key at %s ...\033[0m\n' "$KEY_PATH"
+    mkdir -p "$(dirname "$KEY_PATH")"
+    # pnpm dlx fetches a fresh Tauri CLI for the host platform instead of
+    # using the project's node_modules, which on this repo gets installed
+    # from PowerShell and therefore only carries the Windows native binding.
+    pnpm dlx "@tauri-apps/cli@^2" signer generate -w "$KEY_PATH"
+fi
+
+PRIVATE_KEY="$(cat "$KEY_PATH")"
+PUBLIC_KEY="$(cat "${KEY_PATH}.pub")"
+
+# Capture the password set during key generation
+echo
+read -r -s -p 'Enter the password you set on the signing key (empty if none): ' KEY_PASSWORD
+echo
+
+# Create the public releases repo if it does not yet exist
+if gh repo view "$RELEASES_REPO" --json name >/dev/null 2>&1; then
+    printf '\033[32mReleases repo %s already exists - skipping create.\033[0m\n' "$RELEASES_REPO"
+else
+    printf '\033[36mCreating public repo %s ...\033[0m\n' "$RELEASES_REPO"
+    gh repo create "$RELEASES_REPO" \
+        --public \
+        --description 'Public release artifacts for rustflix (do not push code here)'
+fi
+
+# Fine-grained PAT for the releases repo
+echo
+printf '\033[36m== Create a fine-grained Personal Access Token ==\033[0m\n'
+echo 'Open: https://github.com/settings/personal-access-tokens/new'
+echo '  - Resource owner: henningcullin'
+echo "  - Repository access: Only select repositories -> $RELEASES_REPO"
+echo '  - Permissions -> Repository permissions -> Contents: Read and write'
+echo '  - Expiration: 1 year (or custom)'
+echo
+read -r -s -p 'Paste the generated token: ' PAT
+echo
+
+# Set Actions secrets on the source repo
+printf '\033[36mSetting Actions secrets on the source repo ...\033[0m\n'
+printf '%s' "$PRIVATE_KEY"  | gh secret set TAURI_SIGNING_PRIVATE_KEY          --repo "$SOURCE_REPO"
+printf '%s' "$KEY_PASSWORD" | gh secret set TAURI_SIGNING_PRIVATE_KEY_PASSWORD --repo "$SOURCE_REPO"
+printf '%s' "$PAT"          | gh secret set RELEASES_REPO_TOKEN                --repo "$SOURCE_REPO"
+
+echo
+printf '\033[32m== Done ==\033[0m\n'
+echo
+printf '\033[36mNext steps (manual):\033[0m\n'
+echo '  1. Open src-tauri/tauri.conf.json'
+echo '  2. Replace REPLACE_WITH_OUTPUT_OF_setup-updater with:'
+echo
+printf '\033[33m%s\033[0m\n' "$PUBLIC_KEY"
+echo
+echo '  3. Commit + push.'
+echo "  4. Back up $KEY_PATH (and ${KEY_PATH}.pub) somewhere safe (password"
+echo '     manager). If you lose them, you can never ship updates to existing'
+echo '     installs.'


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` with coding ground rules (control flow, ternaries, naming, branch naming).
- Add `.claude/commands/iterate.md` (slash-command for serial PR work).
- Add `.github/pull_request_template.md` and `.github/workflows/release.yml`.
- Add `.gitattributes` for line-ending normalization.
- Rewrite `README.md` for Rustflix (Tauri+SvelteKit+mpv app).
- Add `scripts/` release + mpv setup helpers (release.{sh,ps1}, setup-updater.{sh,ps1}, fetch-mpv.ps1, SETUP-UPDATER.md).

## Why
Foundational meta files needed before the rest of the rewrite lands. PR/release tooling lets us push subsequent work cleanly.

## Test plan
- [ ] Repo lints/builds unchanged (no source code touched).
- [ ] README renders correctly on GitHub.