### PR TITLE
Fix series detail reloading on watched toggle

### DIFF
--- a/src/routes/series/[id]/+page.svelte
+++ b/src/routes/series/[id]/+page.svelte
@@ -50,12 +50,25 @@
     }
   }
 
-  async function toggleEpisode(epId: number, watched: boolean) {
+  async function toggleEpisode(episodeId: number, watched: boolean) {
+    const next = !watched;
     try {
-      await api.setWatched('episode', epId, !watched);
-      if (show) await load(show.id);
-    } catch (e) {
-      error = String(e);
+      await api.setWatched('episode', episodeId, next);
+
+      for (const season of seasons) {
+        const episode = season.episodes.find((candidate) => candidate.id === episodeId);
+        if (!episode) {
+          continue;
+        }
+
+        episode.watched = next;
+        if (show) {
+          show.watched_count += next ? 1 : -1;
+        }
+        return;
+      }
+    } catch (caught) {
+      error = String(caught);
     }
   }
 


### PR DESCRIPTION
## Summary
- Update `episode.watched` and `show.watched_count` in place after `setWatched`, instead of calling `load(show.id)` and re-fetching the whole show.

## Why
Marking an episode watched or unwatched used to re-fetch the show + seasons, which:
- flashes the "Loading…" placeholder,
- resets the selected season back to season 1,
- resets scroll position on the episode list.

The backend write succeeds without us needing to re-read the world, so the simpler fix is to mutate the local Svelte 5 `$state` objects.

## Test plan
- [x] `pnpm check` passes (0 errors).
- [ ] In `/series/[id]`, toggle "watched" on an episode in season ≥ 2: the season selector stays put, no flash of loading state, and the `X/Y watched` count in the hero subtitle updates immediately.
- [ ] Toggle back to unwatched: count decreases by 1 and the green checkmark disappears.