### PR TITLE
Backend for metadata edits, poster ops, and show merge

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,13 +1,16 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-use tauri::State;
+use tauri::{AppHandle, Manager, State};
 
 use crate::db::Db;
 use crate::error::{AppError, AppResult};
 use crate::models::{
-    ContinueWatchingItem, Episode, Library, LibraryKind, Movie, ScanReport, Season, Show,
+    ContinueWatchingItem, Episode, Library, LibraryKind, MergeOutcome, Movie, ScanReport, Season,
+    Show,
 };
 use crate::{player, queries, scanner};
+
+const ALLOWED_POSTER_EXTS: &[&str] = &["jpg", "jpeg", "png", "webp"];
 
 #[tauri::command]
 pub async fn list_libraries(db: State<'_, Db>) -> AppResult<Vec<Library>> {
@@ -132,4 +135,114 @@ pub async fn play_episode(
     let ep = queries::get_episode(&db, id).await?;
     let start = resume.unwrap_or(ep.progress_seconds);
     player::play(&db, "episode", id, &ep.path, start).await
+}
+
+#[tauri::command]
+pub async fn update_show_metadata(
+    db: State<'_, Db>,
+    id: i64,
+    title: Option<String>,
+    year: Option<i32>,
+    overview: Option<String>,
+) -> AppResult<Show> {
+    queries::update_show_metadata(&db, id, title.as_deref(), year, overview.as_deref()).await?;
+    queries::get_show(&db, id).await
+}
+
+#[tauri::command]
+pub async fn update_movie_metadata(
+    db: State<'_, Db>,
+    id: i64,
+    title: Option<String>,
+    year: Option<i32>,
+    overview: Option<String>,
+) -> AppResult<Movie> {
+    queries::update_movie_metadata(&db, id, title.as_deref(), year, overview.as_deref()).await?;
+    queries::get_movie(&db, id).await
+}
+
+#[tauri::command]
+pub async fn merge_shows(
+    db: State<'_, Db>,
+    target_id: i64,
+    source_id: i64,
+) -> AppResult<MergeOutcome> {
+    queries::merge_shows(&db, target_id, source_id).await
+}
+
+#[tauri::command]
+pub async fn set_show_poster_from_file(
+    app: AppHandle,
+    db: State<'_, Db>,
+    id: i64,
+    source_path: String,
+) -> AppResult<Show> {
+    let destination = copy_poster(&app, "show", id, &source_path).await?;
+    queries::set_show_poster(&db, id, &destination, "manual").await?;
+    queries::get_show(&db, id).await
+}
+
+#[tauri::command]
+pub async fn set_movie_poster_from_file(
+    app: AppHandle,
+    db: State<'_, Db>,
+    id: i64,
+    source_path: String,
+) -> AppResult<Movie> {
+    let destination = copy_poster(&app, "movie", id, &source_path).await?;
+    queries::set_movie_poster(&db, id, &destination, "manual").await?;
+    queries::get_movie(&db, id).await
+}
+
+#[tauri::command]
+pub async fn reset_show_poster(db: State<'_, Db>, id: i64) -> AppResult<Show> {
+    queries::reset_show_poster(&db, id).await?;
+    queries::get_show(&db, id).await
+}
+
+#[tauri::command]
+pub async fn reset_movie_poster(db: State<'_, Db>, id: i64) -> AppResult<Movie> {
+    queries::reset_movie_poster(&db, id).await?;
+    queries::get_movie(&db, id).await
+}
+
+/// Copy `source_path` into `<app_data>/posters/{kind}-{id}.{ext}` and return
+/// the destination path as a string. Rejects sources whose extension isn't
+/// in [`ALLOWED_POSTER_EXTS`] so we don't accidentally accept arbitrary
+/// files.
+async fn copy_poster(
+    app: &AppHandle,
+    kind: &str,
+    id: i64,
+    source_path: &str,
+) -> AppResult<String> {
+    let source = Path::new(source_path);
+    if !source.exists() {
+        return Err(AppError::Other(format!(
+            "source file does not exist: {source_path}"
+        )));
+    }
+
+    let extension = source
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.to_lowercase())
+        .ok_or_else(|| AppError::Other("source file has no extension".to_string()))?;
+    if !ALLOWED_POSTER_EXTS.iter().any(|allowed| *allowed == extension) {
+        return Err(AppError::Other(format!(
+            "unsupported image type: .{extension}"
+        )));
+    }
+
+    let app_data_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|error| AppError::Other(format!("app_data_dir: {error}")))?;
+    let poster_dir = app_data_dir.join("posters");
+    tokio::fs::create_dir_all(&poster_dir).await?;
+
+    let destination = poster_dir.join(format!("{kind}-{id}.{extension}"));
+    tokio::fs::copy(source, &destination).await?;
+
+    Ok(destination.to_string_lossy().to_string())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -40,6 +40,13 @@ pub fn run() {
             commands::check_mpv,
             commands::play_movie,
             commands::play_episode,
+            commands::update_show_metadata,
+            commands::update_movie_metadata,
+            commands::merge_shows,
+            commands::set_show_poster_from_file,
+            commands::set_movie_poster_from_file,
+            commands::reset_show_poster,
+            commands::reset_movie_poster,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -79,3 +79,18 @@ pub struct ScanReport {
     pub episodes_added: usize,
     pub shows_added: usize,
 }
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct EpisodeRef {
+    pub season: i32,
+    pub episode: i32,
+}
+
+/// Result of a merge attempt. If `conflicts` is empty, the merge succeeded.
+/// Otherwise the source show still exists and the listed episodes are the
+/// (season, episode) pairs that exist in both target and source — the user
+/// has to resolve them before the merge can complete.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct MergeOutcome {
+    pub conflicts: Vec<EpisodeRef>,
+}

--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -2,7 +2,8 @@ use sqlx::SqlitePool;
 
 use crate::error::{AppError, AppResult};
 use crate::models::{
-    ContinueWatchingItem, Episode, Library, LibraryKind, Movie, Season, Show,
+    ContinueWatchingItem, Episode, EpisodeRef, Library, LibraryKind, MergeOutcome, Movie, Season,
+    Show,
 };
 
 pub async fn list_libraries(pool: &SqlitePool) -> AppResult<Vec<Library>> {
@@ -161,6 +162,192 @@ pub async fn upsert_progress(
     .execute(pool)
     .await?;
     Ok(())
+}
+
+pub async fn update_show_metadata(
+    pool: &SqlitePool,
+    id: i64,
+    title: Option<&str>,
+    year: Option<i32>,
+    overview: Option<&str>,
+) -> AppResult<()> {
+    update_metadata_row(pool, "shows", id, title, year, overview).await
+}
+
+pub async fn update_movie_metadata(
+    pool: &SqlitePool,
+    id: i64,
+    title: Option<&str>,
+    year: Option<i32>,
+    overview: Option<&str>,
+) -> AppResult<()> {
+    update_metadata_row(pool, "movies", id, title, year, overview).await
+}
+
+/// Shared body for `update_show_metadata` and `update_movie_metadata`. Only
+/// fields passed as `Some` are touched. There's no v1 way to *clear* a field
+/// to NULL through this API; that needs an explicit "reset" command if it
+/// turns out users want it.
+async fn update_metadata_row(
+    pool: &SqlitePool,
+    table: &str,
+    id: i64,
+    title: Option<&str>,
+    year: Option<i32>,
+    overview: Option<&str>,
+) -> AppResult<()> {
+    let mut assignments: Vec<&str> = Vec::new();
+    if title.is_some() {
+        assignments.push("title = ?");
+    }
+    if year.is_some() {
+        assignments.push("year = ?");
+    }
+    if overview.is_some() {
+        assignments.push("overview = ?");
+    }
+    if assignments.is_empty() {
+        return Ok(());
+    }
+
+    let sql = format!("UPDATE {table} SET {} WHERE id = ?", assignments.join(", "));
+
+    let mut query = sqlx::query(&sql);
+    if let Some(value) = title {
+        query = query.bind(value);
+    }
+    if let Some(value) = year {
+        query = query.bind(value);
+    }
+    if let Some(value) = overview {
+        query = query.bind(value);
+    }
+    let result = query.bind(id).execute(pool).await?;
+    if result.rows_affected() == 0 {
+        return Err(AppError::MediaNotFound(id));
+    }
+    Ok(())
+}
+
+pub async fn set_show_poster(
+    pool: &SqlitePool,
+    id: i64,
+    path: &str,
+    origin: &str,
+) -> AppResult<()> {
+    set_poster_row(pool, "shows", id, path, origin).await
+}
+
+pub async fn set_movie_poster(
+    pool: &SqlitePool,
+    id: i64,
+    path: &str,
+    origin: &str,
+) -> AppResult<()> {
+    set_poster_row(pool, "movies", id, path, origin).await
+}
+
+pub async fn reset_show_poster(pool: &SqlitePool, id: i64) -> AppResult<()> {
+    reset_poster_row(pool, "shows", id).await
+}
+
+pub async fn reset_movie_poster(pool: &SqlitePool, id: i64) -> AppResult<()> {
+    reset_poster_row(pool, "movies", id).await
+}
+
+async fn set_poster_row(
+    pool: &SqlitePool,
+    table: &str,
+    id: i64,
+    path: &str,
+    origin: &str,
+) -> AppResult<()> {
+    let sql = format!("UPDATE {table} SET poster_path = ?1, poster_origin = ?2 WHERE id = ?3");
+    let result = sqlx::query(&sql)
+        .bind(path)
+        .bind(origin)
+        .bind(id)
+        .execute(pool)
+        .await?;
+    if result.rows_affected() == 0 {
+        return Err(AppError::MediaNotFound(id));
+    }
+    Ok(())
+}
+
+async fn reset_poster_row(pool: &SqlitePool, table: &str, id: i64) -> AppResult<()> {
+    let sql = format!("UPDATE {table} SET poster_path = NULL, poster_origin = NULL WHERE id = ?1");
+    let result = sqlx::query(&sql).bind(id).execute(pool).await?;
+    if result.rows_affected() == 0 {
+        return Err(AppError::MediaNotFound(id));
+    }
+    Ok(())
+}
+
+/// Reassigns every episode of `source_id` to `target_id` and deletes
+/// `source_id`. If both shows have an episode with the same
+/// `(season, episode)` the merge is rejected — the conflicting pairs are
+/// returned in `MergeOutcome.conflicts` and nothing is changed. Caller can
+/// surface the conflicts to the user and try again after they're resolved.
+pub async fn merge_shows(
+    pool: &SqlitePool,
+    target_id: i64,
+    source_id: i64,
+) -> AppResult<MergeOutcome> {
+    if target_id == source_id {
+        return Err(AppError::Other(
+            "cannot merge a show into itself".to_string(),
+        ));
+    }
+
+    let conflicts: Vec<EpisodeRef> = sqlx::query_as(
+        "SELECT source.season, source.episode
+         FROM episodes source
+         WHERE source.show_id = ?1
+           AND EXISTS (
+               SELECT 1 FROM episodes target
+               WHERE target.show_id = ?2
+                 AND target.season = source.season
+                 AND target.episode = source.episode
+           )
+         ORDER BY source.season, source.episode",
+    )
+    .bind(source_id)
+    .bind(target_id)
+    .fetch_all(pool)
+    .await?;
+
+    if !conflicts.is_empty() {
+        return Ok(MergeOutcome { conflicts });
+    }
+
+    let mut tx = pool.begin().await?;
+    sqlx::query("UPDATE episodes SET show_id = ?1 WHERE show_id = ?2")
+        .bind(target_id)
+        .bind(source_id)
+        .execute(&mut *tx)
+        .await?;
+    let deleted = sqlx::query("DELETE FROM shows WHERE id = ?1")
+        .bind(source_id)
+        .execute(&mut *tx)
+        .await?;
+    if deleted.rows_affected() == 0 {
+        tx.rollback().await?;
+        return Err(AppError::MediaNotFound(source_id));
+    }
+    tx.commit().await?;
+
+    Ok(MergeOutcome { conflicts: vec![] })
+}
+
+impl<'r> sqlx::FromRow<'r, sqlx::sqlite::SqliteRow> for EpisodeRef {
+    fn from_row(row: &'r sqlx::sqlite::SqliteRow) -> Result<Self, sqlx::Error> {
+        use sqlx::Row;
+        Ok(EpisodeRef {
+            season: row.try_get("season")?,
+            episode: row.try_get("episode")?,
+        })
+    }
 }
 
 pub async fn continue_watching(pool: &SqlitePool, limit: i64) -> AppResult<Vec<ContinueWatchingItem>> {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -67,6 +67,30 @@ export interface ScanReport {
   shows_added: number;
 }
 
+export interface EpisodeRef {
+  season: number;
+  episode: number;
+}
+
+export interface MergeOutcome {
+  conflicts: EpisodeRef[];
+}
+
+export interface MetadataPatch {
+  title?: string;
+  year?: number;
+  overview?: string;
+}
+
+export function pickImageFile(): Promise<string | null> {
+  return open({
+    directory: false,
+    multiple: false,
+    title: 'Select a poster image',
+    filters: [{ name: 'Images', extensions: ['jpg', 'jpeg', 'png', 'webp'] }],
+  }) as Promise<string | null>;
+}
+
 export const api = {
   listLibraries: () => invoke<Library[]>('list_libraries'),
   addLibrary: (path: string, kind: LibraryKind = 'mixed') =>
@@ -91,6 +115,19 @@ export const api = {
     invoke<{ session_id: number }>('play_movie', { id, resume }),
   playEpisode: (id: number, resume?: number) =>
     invoke<{ session_id: number }>('play_episode', { id, resume }),
+
+  updateShowMetadata: (id: number, patch: MetadataPatch) =>
+    invoke<Show>('update_show_metadata', { id, ...patch }),
+  updateMovieMetadata: (id: number, patch: MetadataPatch) =>
+    invoke<Movie>('update_movie_metadata', { id, ...patch }),
+  mergeShows: (targetId: number, sourceId: number) =>
+    invoke<MergeOutcome>('merge_shows', { targetId, sourceId }),
+  setShowPosterFromFile: (id: number, sourcePath: string) =>
+    invoke<Show>('set_show_poster_from_file', { id, sourcePath }),
+  setMoviePosterFromFile: (id: number, sourcePath: string) =>
+    invoke<Movie>('set_movie_poster_from_file', { id, sourcePath }),
+  resetShowPoster: (id: number) => invoke<Show>('reset_show_poster', { id }),
+  resetMoviePoster: (id: number) => invoke<Movie>('reset_movie_poster', { id }),
 
   pickFolder: () =>
     open({


### PR DESCRIPTION
## Summary
The IPC surface the upcoming edit UI will call. No frontend changes here.

**Edits** (only fields the caller passes are updated, returns the refreshed row)
- \`update_show_metadata(id, title?, year?, overview?)\`
- \`update_movie_metadata(id, title?, year?, overview?)\`

**Posters**
- \`set_show_poster_from_file(id, sourcePath)\` and movie equivalent — copy into \`<app_data>/posters/{kind}-{id}.{ext}\` (only jpg/jpeg/png/webp), set \`poster_origin = 'manual'\`. Returns the refreshed row.
- \`reset_show_poster(id)\` / \`reset_movie_poster(id)\` — clear \`poster_path\` + \`poster_origin\` so the next scan re-discovers from disk.

**Merge**
- \`merge_shows(targetId, sourceId)\` returns \`MergeOutcome { conflicts }\`. Non-empty conflicts means nothing changed and the caller gets the \`(season, episode)\` pairs that exist in both shows. Wrapped in a transaction.

**Types**
- New \`MergeOutcome\`, \`EpisodeRef\`, \`MetadataPatch\` types in \`src/lib/api.ts\`.
- \`pickImageFile()\` helper in \`api.ts\` opens the Tauri dialog with an image extension filter.

## Why
Foundation for inline + dedicated edit pages. Nothing in this PR is reachable from the UI yet — pure backend additions, no behavior change for users.

## Test plan
- [ ] \`cargo check\` passes (verified locally; build-script failure is the pre-existing Linux mpv binary issue).
- [ ] Subsequent PRs (inline edits, edit route, merge sheet) call these commands and exercise the paths end-to-end.