### PR TITLE
Inline title + poster edits on detail pages

### DIFF
--- a/src/lib/components/HeroBanner.svelte
+++ b/src/lib/components/HeroBanner.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Play } from '$lib/lucide';
+  import { Image as ImageIcon, Pencil, Play, RotateCcw } from '$lib/lucide';
   import { formatRuntime } from '$lib/api';
 
   type Props = {
@@ -11,6 +11,10 @@
     year?: number | null;
     runtime?: number | null;
     backdrop?: string | null;
+    onTitleSave?: (next: string) => Promise<void> | void;
+    onPosterChange?: () => Promise<void> | void;
+    onPosterReset?: () => Promise<void> | void;
+    posterIsManual?: boolean;
   };
 
   let {
@@ -22,10 +26,61 @@
     year,
     runtime,
     backdrop,
+    onTitleSave,
+    onPosterChange,
+    onPosterReset,
+    posterIsManual = false,
   }: Props = $props();
+
+  const isTitleEditable = $derived(typeof onTitleSave === 'function');
+  const isPosterEditable = $derived(typeof onPosterChange === 'function');
+
+  let editingTitle = $state(false);
+  let draftTitle = $state('');
+  let saving = $state(false);
+
+  function startEdit() {
+    if (!isTitleEditable || editingTitle) {
+      return;
+    }
+    draftTitle = title;
+    editingTitle = true;
+  }
+
+  function cancelEdit() {
+    editingTitle = false;
+    draftTitle = '';
+  }
+
+  async function commitEdit() {
+    if (!onTitleSave) {
+      cancelEdit();
+      return;
+    }
+
+    const next = draftTitle.trim();
+    if (next.length === 0 || next === title) {
+      cancelEdit();
+      return;
+    }
+
+    saving = true;
+    try {
+      await onTitleSave(next);
+    } finally {
+      saving = false;
+      editingTitle = false;
+      draftTitle = '';
+    }
+  }
+
+  function autoFocus(node: HTMLInputElement) {
+    node.focus();
+    node.select();
+  }
 </script>
 
-<section class="relative isolate overflow-hidden">
+<section class="group/hero relative isolate overflow-hidden">
   <div class="relative h-[60vh] min-h-[420px] w-full">
     {#if backdrop}
       <img
@@ -40,6 +95,31 @@
     {/if}
     <div class="absolute inset-0 bg-gradient-to-t from-background via-background/40 to-transparent"></div>
     <div class="absolute inset-0 bg-gradient-to-r from-background/90 via-background/40 to-transparent"></div>
+
+    {#if isPosterEditable}
+      <div
+        class="absolute right-4 top-4 flex gap-2 opacity-0 transition-opacity duration-200 group-hover/hero:opacity-100 focus-within:opacity-100"
+      >
+        <button
+          type="button"
+          onclick={() => onPosterChange?.()}
+          class="inline-flex items-center gap-1.5 rounded-md bg-background/80 px-3 py-1.5 text-xs font-medium text-foreground backdrop-blur-sm transition hover:bg-background"
+        >
+          <ImageIcon class="size-3.5" />
+          {backdrop ? 'Change poster' : 'Add poster'}
+        </button>
+        {#if posterIsManual && onPosterReset}
+          <button
+            type="button"
+            onclick={() => onPosterReset?.()}
+            class="inline-flex items-center gap-1.5 rounded-md bg-background/80 px-3 py-1.5 text-xs font-medium text-muted-foreground backdrop-blur-sm transition hover:bg-background hover:text-foreground"
+          >
+            <RotateCcw class="size-3.5" />
+            Reset to auto
+          </button>
+        {/if}
+      </div>
+    {/if}
   </div>
 
   <div class="absolute inset-0 flex items-center px-6 lg:px-12">
@@ -49,9 +129,40 @@
           {subtitle}
         </div>
       {/if}
-      <h1 class="text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
-        {title}
-      </h1>
+
+      {#if editingTitle}
+        <input
+          use:autoFocus
+          bind:value={draftTitle}
+          disabled={saving}
+          onblur={commitEdit}
+          onkeydown={(event) => {
+            if (event.key === 'Enter') {
+              event.preventDefault();
+              void commitEdit();
+            } else if (event.key === 'Escape') {
+              event.preventDefault();
+              cancelEdit();
+            }
+          }}
+          class="w-full max-w-xl rounded-md border border-primary/60 bg-background/60 px-3 py-1.5 text-4xl font-bold tracking-tight text-foreground outline-none backdrop-blur sm:text-5xl lg:text-6xl"
+        />
+      {:else if isTitleEditable}
+        <button
+          type="button"
+          onclick={startEdit}
+          aria-label="Edit title"
+          class="group/title -mx-2 flex items-center gap-3 rounded-md px-2 py-0.5 text-left text-4xl font-bold tracking-tight text-foreground transition hover:bg-background/30 sm:text-5xl lg:text-6xl"
+        >
+          <span>{title}</span>
+          <Pencil class="size-5 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover/title:opacity-100" />
+        </button>
+      {:else}
+        <h1 class="text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
+          {title}
+        </h1>
+      {/if}
+
       <div class="mt-3 flex items-center gap-3 text-sm text-muted-foreground">
         {#if year}<span>{year}</span>{/if}
         {#if runtime}<span>{formatRuntime(runtime)}</span>{/if}

--- a/src/lib/lucide.ts
+++ b/src/lib/lucide.ts
@@ -16,3 +16,5 @@ export { default as ChevronRight } from '@lucide/svelte/icons/chevron-right';
 export { default as Search } from '@lucide/svelte/icons/search';
 export { default as Film } from '@lucide/svelte/icons/film';
 export { default as Image } from '@lucide/svelte/icons/image';
+export { default as Pencil } from '@lucide/svelte/icons/pencil';
+export { default as RotateCcw } from '@lucide/svelte/icons/rotate-ccw';

--- a/src/routes/films/[id]/+page.svelte
+++ b/src/routes/films/[id]/+page.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
   import { page } from '$app/stores';
-  import { api, formatRuntime, progressPct, type Movie } from '$lib/api';
+  import {
+    api,
+    formatRuntime,
+    pickImageFile,
+    progressPct,
+    type Movie,
+  } from '$lib/api';
   import HeroBanner from '$lib/components/HeroBanner.svelte';
   import { Play, Check, Circle } from '$lib/lucide';
 
@@ -42,12 +48,63 @@
   }
 
   async function toggleWatched() {
-    if (!movie) return;
+    if (!movie) {
+      return;
+    }
+    const next = !movie.watched;
     try {
-      await api.setWatched('movie', movie.id, !movie.watched);
-      await load(movie.id);
-    } catch (e) {
-      error = String(e);
+      await api.setWatched('movie', movie.id, next);
+      movie = { ...movie, watched: next };
+    } catch (caught) {
+      error = String(caught);
+    }
+  }
+
+  async function saveTitle(next: string) {
+    if (!movie) {
+      return;
+    }
+    try {
+      const updated = await api.updateMovieMetadata(movie.id, { title: next });
+      movie = { ...movie, title: updated.title };
+    } catch (caught) {
+      error = String(caught);
+    }
+  }
+
+  async function changePoster() {
+    if (!movie) {
+      return;
+    }
+    try {
+      const source = await pickImageFile();
+      if (!source) {
+        return;
+      }
+      const updated = await api.setMoviePosterFromFile(movie.id, source);
+      movie = {
+        ...movie,
+        poster_path: updated.poster_path,
+        poster_origin: updated.poster_origin,
+      };
+    } catch (caught) {
+      error = String(caught);
+    }
+  }
+
+  async function resetPoster() {
+    if (!movie) {
+      return;
+    }
+    try {
+      const updated = await api.resetMoviePoster(movie.id);
+      movie = {
+        ...movie,
+        poster_path: updated.poster_path,
+        poster_origin: updated.poster_origin,
+      };
+    } catch (caught) {
+      error = String(caught);
     }
   }
 </script>
@@ -65,6 +122,10 @@
     year={movie.year}
     runtime={movie.duration_seconds}
     backdrop={movie.poster_path ?? null}
+    posterIsManual={movie.poster_origin === 'manual'}
+    onTitleSave={saveTitle}
+    onPosterChange={changePoster}
+    onPosterReset={resetPoster}
   />
 
   <div class="px-6 py-8 lg:px-12">

--- a/src/routes/series/[id]/+page.svelte
+++ b/src/routes/series/[id]/+page.svelte
@@ -1,6 +1,13 @@
 <script lang="ts">
   import { page } from '$app/stores';
-  import { api, formatRuntime, progressPct, type Season, type Show } from '$lib/api';
+  import {
+    api,
+    formatRuntime,
+    pickImageFile,
+    progressPct,
+    type Season,
+    type Show,
+  } from '$lib/api';
   import HeroBanner from '$lib/components/HeroBanner.svelte';
   import { Check, Circle, Play } from '$lib/lucide';
 
@@ -50,6 +57,54 @@
     }
   }
 
+  async function saveTitle(next: string) {
+    if (!show) {
+      return;
+    }
+    try {
+      const updated = await api.updateShowMetadata(show.id, { title: next });
+      show = { ...show, title: updated.title };
+    } catch (caught) {
+      error = String(caught);
+    }
+  }
+
+  async function changePoster() {
+    if (!show) {
+      return;
+    }
+    try {
+      const source = await pickImageFile();
+      if (!source) {
+        return;
+      }
+      const updated = await api.setShowPosterFromFile(show.id, source);
+      show = {
+        ...show,
+        poster_path: updated.poster_path,
+        poster_origin: updated.poster_origin,
+      };
+    } catch (caught) {
+      error = String(caught);
+    }
+  }
+
+  async function resetPoster() {
+    if (!show) {
+      return;
+    }
+    try {
+      const updated = await api.resetShowPoster(show.id);
+      show = {
+        ...show,
+        poster_path: updated.poster_path,
+        poster_origin: updated.poster_origin,
+      };
+    } catch (caught) {
+      error = String(caught);
+    }
+  }
+
   async function toggleEpisode(episodeId: number, watched: boolean) {
     const next = !watched;
     try {
@@ -89,6 +144,10 @@
     href={`/series/${show.id}`}
     year={show.year}
     backdrop={show.poster_path ?? null}
+    posterIsManual={show.poster_origin === 'manual'}
+    onTitleSave={saveTitle}
+    onPosterChange={changePoster}
+    onPosterReset={resetPoster}
   />
 
   <div class="px-6 py-8 lg:px-12">


### PR DESCRIPTION
## Summary
Click-to-edit title and hover-to-change poster on \`/series/[id]\` and \`/films/[id]\`. Closes the loop on the everyday case for metadata edits — the dedicated edit route lands next for the long tail of fields.

**HeroBanner** now takes optional handlers:
- \`onTitleSave(next)\` — clicking the title swaps it for an autofocused input. Enter / blur commits, Esc cancels. Empty / unchanged input cancels silently. Read-only callers get a plain \`<h1>\` (no behavior change).
- \`onPosterChange\` / \`onPosterReset\` + \`posterIsManual\` — hover overlay top-right: "Change poster" always when editable, "Reset to auto" only when \`posterIsManual\`.

**Series / films detail pages** wire the handlers:
- \`saveTitle\` calls \`update_*_metadata\` and mutates the local \`Show\`/\`Movie\` in place.
- \`changePoster\` opens the Tauri image-only dialog via \`pickImageFile()\`, then \`set_*_poster_from_file\`, then mutates state.
- \`resetPoster\` calls \`reset_*_poster\`.

Also fixed \`films/[id]\` \`toggleWatched\` to mutate in place (same anti-pattern PR #9 fixed for series).

## Test plan
- [ ] Type-check passes (verified via \`tsc\` locally — svelte-check fails only because the user's Windows pnpm install didn't drop the Linux rollup binary; not a code issue).
- [ ] Open a series detail page, click the title, type a new name, press Enter. Reload — change persists. Rescan — still preserved.
- [ ] Click "Change poster", pick an image. Image swaps without a reload. "Reset to auto" appears.
- [ ] Click "Reset to auto". Poster clears. Rescan — re-discovers the on-disk poster.
- [ ] Same flow for a movie detail page.
- [ ] Toggling "watched" on a movie no longer flashes the loading state.