### PR TITLE
Dedicated edit route for series and movies

### DIFF
--- a/src/routes/films/[id]/+page.svelte
+++ b/src/routes/films/[id]/+page.svelte
@@ -8,7 +8,7 @@
     type Movie,
   } from '$lib/api';
   import HeroBanner from '$lib/components/HeroBanner.svelte';
-  import { Play, Check, Circle } from '$lib/lucide';
+  import { Play, Check, Circle, Pencil } from '$lib/lucide';
 
   let movie: Movie | null = $state(null);
   let loading = $state(true);
@@ -162,6 +162,13 @@
           <Circle class="size-4" /> Mark watched
         {/if}
       </button>
+      <a
+        href={`/films/${movie.id}/edit`}
+        class="ml-auto inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-sm font-medium text-muted-foreground transition hover:bg-accent hover:text-foreground"
+      >
+        <Pencil class="size-3.5" />
+        Edit details
+      </a>
     </div>
 
     {#if !movie.watched && movie.progress_seconds > 0 && movie.duration_seconds}

--- a/src/routes/films/[id]/edit/+page.svelte
+++ b/src/routes/films/[id]/edit/+page.svelte
@@ -1,0 +1,270 @@
+<script lang="ts">
+  import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
+  import { api, pickImageFile, type MetadataPatch, type Movie } from '$lib/api';
+  import { Button } from '$lib/components/ui/button';
+  import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+  } from '$lib/components/ui/card';
+  import { Input } from '$lib/components/ui/input';
+  import { ChevronLeft, Image as ImageIcon, RotateCcw } from '$lib/lucide';
+
+  let movie: Movie | null = $state(null);
+  let loading = $state(true);
+  let saving = $state(false);
+  let busyPoster = $state(false);
+  let error = $state<string | null>(null);
+
+  let titleDraft = $state('');
+  let yearDraft = $state('');
+  let overviewDraft = $state('');
+
+  const id = $derived(Number($page.params.id));
+
+  $effect(() => {
+    if (!Number.isFinite(id)) {
+      return;
+    }
+    void load(id);
+  });
+
+  async function load(movieId: number) {
+    loading = true;
+    error = null;
+    try {
+      const loaded = await api.getMovie(movieId);
+      movie = loaded;
+      titleDraft = loaded.title;
+      yearDraft = loaded.year == null ? '' : String(loaded.year);
+      overviewDraft = loaded.overview ?? '';
+    } catch (caught) {
+      error = String(caught);
+    } finally {
+      loading = false;
+    }
+  }
+
+  function buildPatch(): MetadataPatch | null {
+    if (!movie) {
+      return null;
+    }
+
+    const patch: MetadataPatch = {};
+    const nextTitle = titleDraft.trim();
+    if (nextTitle.length > 0 && nextTitle !== movie.title) {
+      patch.title = nextTitle;
+    }
+
+    const trimmedYear = yearDraft.trim();
+    if (trimmedYear.length > 0) {
+      const parsed = Number(trimmedYear);
+      if (Number.isInteger(parsed) && parsed > 0 && parsed !== movie.year) {
+        patch.year = parsed;
+      }
+    }
+
+    const nextOverview = overviewDraft.trim();
+    if (nextOverview.length > 0 && nextOverview !== (movie.overview ?? '')) {
+      patch.overview = nextOverview;
+    }
+
+    return Object.keys(patch).length === 0 ? null : patch;
+  }
+
+  async function save() {
+    if (!movie) {
+      return;
+    }
+
+    const patch = buildPatch();
+    if (!patch) {
+      await goto(`/films/${movie.id}`);
+      return;
+    }
+
+    saving = true;
+    error = null;
+    try {
+      await api.updateMovieMetadata(movie.id, patch);
+      await goto(`/films/${movie.id}`);
+    } catch (caught) {
+      error = String(caught);
+    } finally {
+      saving = false;
+    }
+  }
+
+  async function changePoster() {
+    if (!movie) {
+      return;
+    }
+    busyPoster = true;
+    try {
+      const source = await pickImageFile();
+      if (!source) {
+        return;
+      }
+      const updated = await api.setMoviePosterFromFile(movie.id, source);
+      movie = updated;
+    } catch (caught) {
+      error = String(caught);
+    } finally {
+      busyPoster = false;
+    }
+  }
+
+  async function resetPoster() {
+    if (!movie) {
+      return;
+    }
+    busyPoster = true;
+    try {
+      const updated = await api.resetMoviePoster(movie.id);
+      movie = updated;
+    } catch (caught) {
+      error = String(caught);
+    } finally {
+      busyPoster = false;
+    }
+  }
+</script>
+
+<div class="mx-auto max-w-3xl px-6 py-8">
+  <a
+    href={movie ? `/films/${movie.id}` : '/films'}
+    class="mb-6 inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+  >
+    <ChevronLeft class="size-4" />
+    Back
+  </a>
+
+  <header class="mb-6">
+    <h1 class="text-3xl font-bold tracking-tight">Edit movie</h1>
+    {#if movie}
+      <p class="text-sm text-muted-foreground">{movie.title}</p>
+    {/if}
+  </header>
+
+  {#if error}
+    <div
+      class="mb-6 rounded-md border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive-foreground"
+    >
+      {error}
+    </div>
+  {/if}
+
+  {#if loading}
+    <p class="text-muted-foreground">Loading…</p>
+  {:else if !movie}
+    <p class="text-destructive-foreground">Movie not found.</p>
+  {:else}
+    <div class="flex flex-col gap-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Basic</CardTitle>
+          <CardDescription>Title, year, and short overview.</CardDescription>
+        </CardHeader>
+        <CardContent class="flex flex-col gap-4">
+          <label class="flex flex-col gap-1.5 text-sm">
+            <span class="font-medium">Title</span>
+            <Input bind:value={titleDraft} placeholder="Movie title" />
+          </label>
+          <label class="flex flex-col gap-1.5 text-sm">
+            <span class="font-medium">Year</span>
+            <Input
+              type="number"
+              bind:value={yearDraft}
+              placeholder="e.g. 1999"
+              inputmode="numeric"
+            />
+          </label>
+          <label class="flex flex-col gap-1.5 text-sm">
+            <span class="font-medium">Overview</span>
+            <textarea
+              bind:value={overviewDraft}
+              rows="4"
+              placeholder="Short description of the movie"
+              class="rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            ></textarea>
+          </label>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Artwork</CardTitle>
+          <CardDescription>
+            Scanner auto-discovers <code class="font-mono text-xs">poster.jpg</code> next to the
+            movie file. Override here for a custom image.
+          </CardDescription>
+        </CardHeader>
+        <CardContent class="flex flex-wrap items-start gap-5">
+          <div class="aspect-[2/3] w-32 shrink-0 overflow-hidden rounded-md border border-border bg-card">
+            {#if movie.poster_path}
+              <img
+                src={movie.poster_path}
+                alt=""
+                class="h-full w-full object-cover"
+              />
+            {:else}
+              <div class="flex h-full w-full items-center justify-center bg-muted">
+                <ImageIcon class="size-8 text-muted-foreground/60" />
+              </div>
+            {/if}
+          </div>
+          <div class="flex flex-col gap-2">
+            <p class="text-sm">
+              {#if movie.poster_origin === 'manual'}
+                Currently using your uploaded poster.
+              {:else if movie.poster_origin === 'auto'}
+                Currently using the poster found next to your files.
+              {:else}
+                No poster set. Drop a <code class="font-mono text-xs">poster.jpg</code> next to the
+                movie file or pick one below.
+              {/if}
+            </p>
+            <div class="flex flex-wrap gap-2">
+              <Button variant="default" size="sm" onclick={changePoster} disabled={busyPoster}>
+                <ImageIcon class="mr-1.5 size-4" />
+                Change poster
+              </Button>
+              {#if movie.poster_origin === 'manual'}
+                <Button variant="secondary" size="sm" onclick={resetPoster} disabled={busyPoster}>
+                  <RotateCcw class="mr-1.5 size-4" />
+                  Reset to auto
+                </Button>
+              {/if}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Advanced</CardTitle>
+          <CardDescription>
+            More fields will appear here as Rustflix learns about your media — cast, ratings,
+            language, genres.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+
+      <div class="flex justify-end gap-2">
+        <Button
+          variant="ghost"
+          onclick={() => movie && goto(`/films/${movie.id}`)}
+          disabled={saving}
+        >
+          Cancel
+        </Button>
+        <Button onclick={save} disabled={saving}>
+          {saving ? 'Saving…' : 'Save'}
+        </Button>
+      </div>
+    </div>
+  {/if}
+</div>

--- a/src/routes/films/[id]/edit/+page.ts
+++ b/src/routes/films/[id]/edit/+page.ts
@@ -1,0 +1,2 @@
+// Dynamic route — must be rendered client-side
+export const prerender = false;

--- a/src/routes/series/[id]/+page.svelte
+++ b/src/routes/series/[id]/+page.svelte
@@ -9,7 +9,7 @@
     type Show,
   } from '$lib/api';
   import HeroBanner from '$lib/components/HeroBanner.svelte';
-  import { Check, Circle, Play } from '$lib/lucide';
+  import { Check, Circle, Pencil, Play } from '$lib/lucide';
 
   let show: Show | null = $state(null);
   let seasons: Season[] = $state([]);
@@ -151,8 +151,8 @@
   />
 
   <div class="px-6 py-8 lg:px-12">
-    {#if nextUp}
-      <div class="mb-8 flex flex-wrap items-center gap-3">
+    <div class="mb-8 flex flex-wrap items-center gap-3">
+      {#if nextUp}
         <button
           type="button"
           onclick={() => playEpisode(nextUp.id, nextUp.progress_seconds < 30)}
@@ -162,8 +162,16 @@
           {nextUp.progress_seconds > 30 ? 'Resume' : 'Play'} S{String(nextUp.season).padStart(2, '0')}E{String(nextUp.episode).padStart(2, '0')}
         </button>
         <span class="text-sm text-muted-foreground">{nextUp.title}</span>
-      </div>
-    {/if}
+      {/if}
+      <a
+        href={`/series/${show.id}/edit`}
+        class="ml-auto inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-sm font-medium text-muted-foreground transition hover:bg-accent hover:text-foreground"
+      >
+        <Pencil class="size-3.5" />
+        Edit details
+      </a>
+    </div>
+
 
     {#if seasons.length > 1}
       <div class="mb-4 flex flex-wrap gap-2">

--- a/src/routes/series/[id]/edit/+page.svelte
+++ b/src/routes/series/[id]/edit/+page.svelte
@@ -1,0 +1,270 @@
+<script lang="ts">
+  import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
+  import { api, pickImageFile, type MetadataPatch, type Show } from '$lib/api';
+  import { Button } from '$lib/components/ui/button';
+  import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+  } from '$lib/components/ui/card';
+  import { Input } from '$lib/components/ui/input';
+  import { ChevronLeft, Image as ImageIcon, RotateCcw } from '$lib/lucide';
+
+  let show: Show | null = $state(null);
+  let loading = $state(true);
+  let saving = $state(false);
+  let busyPoster = $state(false);
+  let error = $state<string | null>(null);
+
+  let titleDraft = $state('');
+  let yearDraft = $state('');
+  let overviewDraft = $state('');
+
+  const id = $derived(Number($page.params.id));
+
+  $effect(() => {
+    if (!Number.isFinite(id)) {
+      return;
+    }
+    void load(id);
+  });
+
+  async function load(showId: number) {
+    loading = true;
+    error = null;
+    try {
+      const loaded = await api.getShow(showId);
+      show = loaded;
+      titleDraft = loaded.title;
+      yearDraft = loaded.year == null ? '' : String(loaded.year);
+      overviewDraft = loaded.overview ?? '';
+    } catch (caught) {
+      error = String(caught);
+    } finally {
+      loading = false;
+    }
+  }
+
+  function buildPatch(): MetadataPatch | null {
+    if (!show) {
+      return null;
+    }
+
+    const patch: MetadataPatch = {};
+    const nextTitle = titleDraft.trim();
+    if (nextTitle.length > 0 && nextTitle !== show.title) {
+      patch.title = nextTitle;
+    }
+
+    const trimmedYear = yearDraft.trim();
+    if (trimmedYear.length > 0) {
+      const parsed = Number(trimmedYear);
+      if (Number.isInteger(parsed) && parsed > 0 && parsed !== show.year) {
+        patch.year = parsed;
+      }
+    }
+
+    const nextOverview = overviewDraft.trim();
+    if (nextOverview.length > 0 && nextOverview !== (show.overview ?? '')) {
+      patch.overview = nextOverview;
+    }
+
+    return Object.keys(patch).length === 0 ? null : patch;
+  }
+
+  async function save() {
+    if (!show) {
+      return;
+    }
+
+    const patch = buildPatch();
+    if (!patch) {
+      await goto(`/series/${show.id}`);
+      return;
+    }
+
+    saving = true;
+    error = null;
+    try {
+      await api.updateShowMetadata(show.id, patch);
+      await goto(`/series/${show.id}`);
+    } catch (caught) {
+      error = String(caught);
+    } finally {
+      saving = false;
+    }
+  }
+
+  async function changePoster() {
+    if (!show) {
+      return;
+    }
+    busyPoster = true;
+    try {
+      const source = await pickImageFile();
+      if (!source) {
+        return;
+      }
+      const updated = await api.setShowPosterFromFile(show.id, source);
+      show = updated;
+    } catch (caught) {
+      error = String(caught);
+    } finally {
+      busyPoster = false;
+    }
+  }
+
+  async function resetPoster() {
+    if (!show) {
+      return;
+    }
+    busyPoster = true;
+    try {
+      const updated = await api.resetShowPoster(show.id);
+      show = updated;
+    } catch (caught) {
+      error = String(caught);
+    } finally {
+      busyPoster = false;
+    }
+  }
+</script>
+
+<div class="mx-auto max-w-3xl px-6 py-8">
+  <a
+    href={show ? `/series/${show.id}` : '/series'}
+    class="mb-6 inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+  >
+    <ChevronLeft class="size-4" />
+    Back
+  </a>
+
+  <header class="mb-6">
+    <h1 class="text-3xl font-bold tracking-tight">Edit series</h1>
+    {#if show}
+      <p class="text-sm text-muted-foreground">{show.title}</p>
+    {/if}
+  </header>
+
+  {#if error}
+    <div
+      class="mb-6 rounded-md border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive-foreground"
+    >
+      {error}
+    </div>
+  {/if}
+
+  {#if loading}
+    <p class="text-muted-foreground">Loading…</p>
+  {:else if !show}
+    <p class="text-destructive-foreground">Series not found.</p>
+  {:else}
+    <div class="flex flex-col gap-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Basic</CardTitle>
+          <CardDescription>Title, year, and short overview.</CardDescription>
+        </CardHeader>
+        <CardContent class="flex flex-col gap-4">
+          <label class="flex flex-col gap-1.5 text-sm">
+            <span class="font-medium">Title</span>
+            <Input bind:value={titleDraft} placeholder="Series title" />
+          </label>
+          <label class="flex flex-col gap-1.5 text-sm">
+            <span class="font-medium">Year</span>
+            <Input
+              type="number"
+              bind:value={yearDraft}
+              placeholder="e.g. 2008"
+              inputmode="numeric"
+            />
+          </label>
+          <label class="flex flex-col gap-1.5 text-sm">
+            <span class="font-medium">Overview</span>
+            <textarea
+              bind:value={overviewDraft}
+              rows="4"
+              placeholder="Short description of the series"
+              class="rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            ></textarea>
+          </label>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Artwork</CardTitle>
+          <CardDescription>
+            Scanner auto-discovers <code class="font-mono text-xs">poster.jpg</code> next to your
+            media. Override here for a custom image.
+          </CardDescription>
+        </CardHeader>
+        <CardContent class="flex flex-wrap items-start gap-5">
+          <div class="aspect-[2/3] w-32 shrink-0 overflow-hidden rounded-md border border-border bg-card">
+            {#if show.poster_path}
+              <img
+                src={show.poster_path}
+                alt=""
+                class="h-full w-full object-cover"
+              />
+            {:else}
+              <div class="flex h-full w-full items-center justify-center bg-muted">
+                <ImageIcon class="size-8 text-muted-foreground/60" />
+              </div>
+            {/if}
+          </div>
+          <div class="flex flex-col gap-2">
+            <p class="text-sm">
+              {#if show.poster_origin === 'manual'}
+                Currently using your uploaded poster.
+              {:else if show.poster_origin === 'auto'}
+                Currently using the poster found next to your files.
+              {:else}
+                No poster set. Drop a <code class="font-mono text-xs">poster.jpg</code> next to your
+                media or pick one below.
+              {/if}
+            </p>
+            <div class="flex flex-wrap gap-2">
+              <Button variant="default" size="sm" onclick={changePoster} disabled={busyPoster}>
+                <ImageIcon class="mr-1.5 size-4" />
+                Change poster
+              </Button>
+              {#if show.poster_origin === 'manual'}
+                <Button variant="secondary" size="sm" onclick={resetPoster} disabled={busyPoster}>
+                  <RotateCcw class="mr-1.5 size-4" />
+                  Reset to auto
+                </Button>
+              {/if}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Advanced</CardTitle>
+          <CardDescription>
+            More fields will appear here as Rustflix learns about your media — cast, ratings,
+            language, genres.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+
+      <div class="flex justify-end gap-2">
+        <Button
+          variant="ghost"
+          onclick={() => show && goto(`/series/${show.id}`)}
+          disabled={saving}
+        >
+          Cancel
+        </Button>
+        <Button onclick={save} disabled={saving}>
+          {saving ? 'Saving…' : 'Save'}
+        </Button>
+      </div>
+    </div>
+  {/if}
+</div>

--- a/src/routes/series/[id]/edit/+page.ts
+++ b/src/routes/series/[id]/edit/+page.ts
@@ -1,0 +1,2 @@
+// Dynamic route — must be rendered client-side
+export const prerender = false;


### PR DESCRIPTION
## Summary
New routes \`/series/[id]/edit\` and \`/films/[id]/edit\` with a sectioned form. The home for everything that doesn't fit the inline quick-edit pattern — and the place where future metadata sections (cast, ratings, language, genres) will land without bloating the detail page.

**Form sections** (shadcn \`Card\` + \`Input\` + \`Button\`)
- **Basic** — title, year, overview (textarea).
- **Artwork** — current poster preview + Change / Reset to auto buttons. Same backend calls as the inline poster swap.
- **Advanced** — placeholder card. Sections grow into this slot.

**Save semantics**
- \`buildPatch()\` only sends fields the user actually changed. Hitting Save with no edits short-circuits to a no-op navigation back to the detail page.
- Year is parsed as a positive integer; blank input skips the field.

**Discovery**
Detail pages (\`/series/[id]\`, \`/films/[id]\`) get an "Edit details" link in the existing action bar so the new route is actually reachable.

## Test plan
- [ ] \`tsc\` passes (verified; svelte-check still fails only on the WSL rollup issue).
- [ ] From a series detail page click "Edit details" → form prefills with current values.
- [ ] Change title and year, click Save → back on detail page, values updated.
- [ ] Hit Save with no edits → navigates back, no IPC call.
- [ ] Artwork: Change poster works the same as inline; Reset to auto only shows when poster_origin is manual.
- [ ] Same flow for a movie.
- [ ] Empty fields (year, overview) don't accidentally wipe data.