### PR TITLE
Manual merge sheet for shows the scanner missed

### DIFF
--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -34,6 +34,7 @@ pub struct Movie {
 #[derive(Debug, Serialize, Deserialize, Clone, sqlx::FromRow)]
 pub struct Show {
     pub id: i64,
+    pub library_id: i64,
     pub title: String,
     pub year: Option<i32>,
     pub folder_path: String,

--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -69,7 +69,7 @@ pub async fn get_movie(pool: &SqlitePool, id: i64) -> AppResult<Movie> {
 }
 
 const SHOW_SELECT: &str = "
-    SELECT s.id, s.title, s.year, s.folder_path, s.fingerprint,
+    SELECT s.id, s.library_id, s.title, s.year, s.folder_path, s.fingerprint,
            s.poster_path, s.poster_origin, s.overview,
            (SELECT COUNT(*) FROM episodes e WHERE e.show_id = s.id) AS episode_count,
            (SELECT COUNT(*) FROM episodes e

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -27,6 +27,7 @@ export interface Movie {
 
 export interface Show {
   id: number;
+  library_id: number;
   title: string;
   year: number | null;
   folder_path: string;

--- a/src/lib/components/MergeShowSheet.svelte
+++ b/src/lib/components/MergeShowSheet.svelte
@@ -1,0 +1,156 @@
+<script lang="ts">
+  import { api, type EpisodeRef, type Show } from '$lib/api';
+  import { Button } from '$lib/components/ui/button';
+  import { Input } from '$lib/components/ui/input';
+  import * as Sheet from '$lib/components/ui/sheet';
+  import { AlertTriangle, GitMerge } from '$lib/lucide';
+
+  type Props = {
+    open: boolean;
+    show: Show;
+    onClose: () => void;
+    onMerged: () => void | Promise<void>;
+  };
+
+  let { open = $bindable(), show, onClose, onMerged }: Props = $props();
+
+  let candidates: Show[] = $state([]);
+  let loading = $state(false);
+  let query = $state('');
+  let busy = $state(false);
+  let error = $state<string | null>(null);
+  let conflicts: EpisodeRef[] = $state([]);
+  let conflictWith = $state<string | null>(null);
+
+  $effect(() => {
+    if (open) {
+      void loadCandidates();
+      return;
+    }
+    candidates = [];
+    query = '';
+    conflicts = [];
+    conflictWith = null;
+    error = null;
+  });
+
+  async function loadCandidates() {
+    loading = true;
+    error = null;
+    try {
+      const all = await api.listShows();
+      candidates = all.filter(
+        (other) => other.id !== show.id && other.library_id === show.library_id,
+      );
+    } catch (caught) {
+      error = String(caught);
+    } finally {
+      loading = false;
+    }
+  }
+
+  const filtered = $derived.by(() => {
+    const needle = query.trim().toLowerCase();
+    if (needle.length === 0) {
+      return candidates;
+    }
+    return candidates.filter((candidate) => candidate.title.toLowerCase().includes(needle));
+  });
+
+  async function attemptMerge(candidate: Show) {
+    busy = true;
+    conflicts = [];
+    conflictWith = null;
+    error = null;
+    try {
+      const outcome = await api.mergeShows(show.id, candidate.id);
+      if (outcome.conflicts.length > 0) {
+        conflicts = outcome.conflicts;
+        conflictWith = candidate.title;
+        return;
+      }
+      await onMerged();
+      onClose();
+    } catch (caught) {
+      error = String(caught);
+    } finally {
+      busy = false;
+    }
+  }
+</script>
+
+<Sheet.Root bind:open>
+  <Sheet.Content side="right" class="flex w-full flex-col gap-4 sm:max-w-md">
+    <Sheet.Header>
+      <Sheet.Title>Merge with another show</Sheet.Title>
+      <Sheet.Description>
+        Pick a show in this library — its episodes will move into "{show.title}" and the other
+        entry will be deleted.
+      </Sheet.Description>
+    </Sheet.Header>
+
+    {#if error}
+      <div
+        class="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive-foreground"
+      >
+        {error}
+      </div>
+    {/if}
+
+    {#if conflicts.length > 0}
+      <div class="rounded-md border border-yellow-500/30 bg-yellow-500/10 p-3 text-sm">
+        <div class="mb-2 flex items-center gap-2 font-medium text-yellow-200">
+          <AlertTriangle class="size-4" />
+          <span>Can't merge with {conflictWith}</span>
+        </div>
+        <p class="mb-2 text-muted-foreground">
+          These episodes exist in both shows — resolve the duplicates first, then try again:
+        </p>
+        <ul class="list-disc pl-5 text-muted-foreground">
+          {#each conflicts as conflict (`${conflict.season}-${conflict.episode}`)}
+            <li>
+              S{String(conflict.season).padStart(2, '0')}E{String(conflict.episode).padStart(2, '0')}
+            </li>
+          {/each}
+        </ul>
+      </div>
+    {/if}
+
+    <Input bind:value={query} placeholder="Search shows…" />
+
+    <div class="-mx-2 flex-1 overflow-y-auto px-2">
+      {#if loading}
+        <p class="text-sm text-muted-foreground">Loading…</p>
+      {:else if filtered.length === 0}
+        <p class="text-sm text-muted-foreground">
+          {query ? 'No matching shows.' : 'No other shows in this library.'}
+        </p>
+      {:else}
+        <ul class="divide-y divide-border rounded-md border border-border">
+          {#each filtered as candidate (candidate.id)}
+            <li>
+              <button
+                type="button"
+                onclick={() => attemptMerge(candidate)}
+                disabled={busy}
+                class="flex w-full items-center justify-between gap-3 px-4 py-3 text-left transition-colors hover:bg-accent disabled:opacity-50"
+              >
+                <div class="min-w-0 flex-1">
+                  <div class="truncate font-medium">{candidate.title}</div>
+                  <div class="text-xs text-muted-foreground">
+                    {candidate.episode_count} episodes{candidate.year ? ` · ${candidate.year}` : ''}
+                  </div>
+                </div>
+                <GitMerge class="size-4 shrink-0 text-muted-foreground" />
+              </button>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </div>
+
+    <Sheet.Footer>
+      <Button variant="ghost" onclick={onClose} disabled={busy}>Cancel</Button>
+    </Sheet.Footer>
+  </Sheet.Content>
+</Sheet.Root>

--- a/src/lib/lucide.ts
+++ b/src/lib/lucide.ts
@@ -18,3 +18,6 @@ export { default as Film } from '@lucide/svelte/icons/film';
 export { default as Image } from '@lucide/svelte/icons/image';
 export { default as Pencil } from '@lucide/svelte/icons/pencil';
 export { default as RotateCcw } from '@lucide/svelte/icons/rotate-ccw';
+export { default as AlertTriangle } from '@lucide/svelte/icons/alert-triangle';
+export { default as GitMerge } from '@lucide/svelte/icons/git-merge';
+export { default as MoreHorizontal } from '@lucide/svelte/icons/more-horizontal';

--- a/src/routes/series/[id]/+page.svelte
+++ b/src/routes/series/[id]/+page.svelte
@@ -9,13 +9,15 @@
     type Show,
   } from '$lib/api';
   import HeroBanner from '$lib/components/HeroBanner.svelte';
-  import { Check, Circle, Pencil, Play } from '$lib/lucide';
+  import MergeShowSheet from '$lib/components/MergeShowSheet.svelte';
+  import { Check, Circle, GitMerge, Pencil, Play } from '$lib/lucide';
 
   let show: Show | null = $state(null);
   let seasons: Season[] = $state([]);
   let loading = $state(true);
   let error = $state<string | null>(null);
   let selectedSeason = $state<number | null>(null);
+  let mergeOpen = $state(false);
 
   const id = $derived(Number($page.params.id));
 
@@ -163,13 +165,23 @@
         </button>
         <span class="text-sm text-muted-foreground">{nextUp.title}</span>
       {/if}
-      <a
-        href={`/series/${show.id}/edit`}
-        class="ml-auto inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-sm font-medium text-muted-foreground transition hover:bg-accent hover:text-foreground"
-      >
-        <Pencil class="size-3.5" />
-        Edit details
-      </a>
+      <div class="ml-auto flex items-center gap-2">
+        <button
+          type="button"
+          onclick={() => (mergeOpen = true)}
+          class="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-sm font-medium text-muted-foreground transition hover:bg-accent hover:text-foreground"
+        >
+          <GitMerge class="size-3.5" />
+          Merge…
+        </button>
+        <a
+          href={`/series/${show.id}/edit`}
+          class="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-sm font-medium text-muted-foreground transition hover:bg-accent hover:text-foreground"
+        >
+          <Pencil class="size-3.5" />
+          Edit details
+        </a>
+      </div>
     </div>
 
 
@@ -189,6 +201,13 @@
         {/each}
       </div>
     {/if}
+
+    <MergeShowSheet
+      bind:open={mergeOpen}
+      {show}
+      onClose={() => (mergeOpen = false)}
+      onMerged={() => show && load(show.id)}
+    />
 
     {#if activeSeason}
       <ul class="divide-y divide-border overflow-hidden rounded-lg border border-border bg-card">


### PR DESCRIPTION
## Summary
The escape hatch for the long tail where the scanner's fingerprint dedup misses — folders like \`BrBa/\` and \`Breaking Bad/\` that don't share a normalized name. Users can now manually merge them from the show detail page.

**MergeShowSheet** (\`src/lib/components/MergeShowSheet.svelte\`)
- shadcn \`Sheet\` anchored to the right side of \`/series/[id]\`. Triggered by a new "Merge…" button in the action bar (next to "Edit details").
- Lists every other show in the same library, with a search input.
- Click a candidate → \`merge_shows(target = current, source = clicked)\`. The other show's episodes move into the current show; the other row is deleted.
- On (season, episode) collision the backend returns \`MergeOutcome.conflicts\` non-empty. The sheet shows a yellow banner naming the candidate + the colliding pairs. Nothing changes; user resolves and tries again.

**Required schema visibility**
\`library_id\` is now exposed on \`Show\` — required to filter merge candidates to the same library. Added to \`models.rs\`, the SHOW_SELECT in \`queries.rs\`, and the TS \`Show\` interface. No data migration needed (column already existed).

## Test plan
- [ ] \`cargo check\` passes (verified).
- [ ] \`tsc\` passes (verified; svelte-check still WSL-only flaky).
- [ ] Create two shows in the same library with non-mergeable filesystem names. Open one, click "Merge…", search for the other, click it → episodes consolidate into the current show; the other entry vanishes.
- [ ] Force a collision (both shows have S01E01). Confirm yellow banner with the right episodes; nothing is modified.
- [ ] Search input filters the candidate list.
- [ ] Shows in *other* libraries don't appear in the candidate list.