### PR TITLE
Delete series from library (db-only, files untouched)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -171,6 +171,39 @@ pub async fn merge_shows(
 }
 
 #[tauri::command]
+pub async fn delete_show(app: AppHandle, db: State<'_, Db>, id: i64) -> AppResult<()> {
+    let show = queries::get_show(&db, id).await?;
+
+    queries::delete_show(&db, id).await?;
+
+    if show.poster_origin.as_deref() == Some("manual") {
+        if let Some(poster_path) = show.poster_path.as_deref() {
+            try_remove_managed_poster(&app, poster_path).await;
+        }
+    }
+
+    Ok(())
+}
+
+/// Best-effort cleanup of a manual poster file. Only deletes the file when
+/// it sits inside our own `<app_data>/posters/` directory — any other path
+/// is ignored so a malformed `poster_path` can never remove user media.
+async fn try_remove_managed_poster(app: &AppHandle, poster_path: &str) {
+    let app_data_dir = match app.path().app_data_dir() {
+        Ok(dir) => dir,
+        Err(_) => return,
+    };
+    let posters_dir = app_data_dir.join("posters");
+
+    let candidate = Path::new(poster_path);
+    if !candidate.starts_with(&posters_dir) {
+        return;
+    }
+
+    let _ = tokio::fs::remove_file(candidate).await;
+}
+
+#[tauri::command]
 pub async fn set_show_poster_from_file(
     app: AppHandle,
     db: State<'_, Db>,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -43,6 +43,7 @@ pub fn run() {
             commands::update_show_metadata,
             commands::update_movie_metadata,
             commands::merge_shows,
+            commands::delete_show,
             commands::set_show_poster_from_file,
             commands::set_movie_poster_from_file,
             commands::reset_show_poster,

--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -340,6 +340,38 @@ pub async fn merge_shows(
     Ok(MergeOutcome { conflicts: vec![] })
 }
 
+/// Removes a show and all of its episodes from the library. Files on disk
+/// are not touched — only DB rows are deleted. Orphan `watch_history` rows
+/// for the show's episodes are cleaned up in the same transaction.
+pub async fn delete_show(pool: &SqlitePool, show_id: i64) -> AppResult<()> {
+    let mut tx = pool.begin().await?;
+
+    let episode_ids: Vec<i64> = sqlx::query_scalar("SELECT id FROM episodes WHERE show_id = ?1")
+        .bind(show_id)
+        .fetch_all(&mut *tx)
+        .await?;
+
+    for episode_id in episode_ids {
+        sqlx::query("DELETE FROM watch_history WHERE media_kind = 'episode' AND media_id = ?1")
+            .bind(episode_id)
+            .execute(&mut *tx)
+            .await?;
+    }
+
+    let deleted = sqlx::query("DELETE FROM shows WHERE id = ?1")
+        .bind(show_id)
+        .execute(&mut *tx)
+        .await?;
+    if deleted.rows_affected() == 0 {
+        tx.rollback().await?;
+        return Err(AppError::MediaNotFound(show_id));
+    }
+
+    tx.commit().await?;
+
+    Ok(())
+}
+
 impl<'r> sqlx::FromRow<'r, sqlx::sqlite::SqliteRow> for EpisodeRef {
     fn from_row(row: &'r sqlx::sqlite::SqliteRow) -> Result<Self, sqlx::Error> {
         use sqlx::Row;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -123,6 +123,7 @@ export const api = {
     invoke<Movie>('update_movie_metadata', { id, ...patch }),
   mergeShows: (targetId: number, sourceId: number) =>
     invoke<MergeOutcome>('merge_shows', { targetId, sourceId }),
+  deleteShow: (id: number) => invoke<void>('delete_show', { id }),
   setShowPosterFromFile: (id: number, sourcePath: string) =>
     invoke<Show>('set_show_poster_from_file', { id, sourcePath }),
   setMoviePosterFromFile: (id: number, sourcePath: string) =>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-action.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-action.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import { AlertDialog as AlertDialogPrimitive } from 'bits-ui';
+  import { buttonVariants, type ButtonVariant } from '$lib/components/ui/button';
+  import { cn } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    variant = 'default',
+    ...restProps
+  }: AlertDialogPrimitive.ActionProps & { variant?: ButtonVariant } = $props();
+</script>
+
+<AlertDialogPrimitive.Action
+  bind:ref
+  class={cn(buttonVariants({ variant }), className)}
+  {...restProps}
+/>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-cancel.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-cancel.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { AlertDialog as AlertDialogPrimitive } from 'bits-ui';
+  import { buttonVariants } from '$lib/components/ui/button';
+  import { cn } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    ...restProps
+  }: AlertDialogPrimitive.CancelProps = $props();
+</script>
+
+<AlertDialogPrimitive.Cancel
+  bind:ref
+  class={cn(buttonVariants({ variant: 'outline' }), 'mt-2 sm:mt-0', className)}
+  {...restProps}
+/>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-content.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-content.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import { AlertDialog as AlertDialogPrimitive, type WithoutChildrenOrChild } from 'bits-ui';
+  import type { Snippet } from 'svelte';
+  import AlertDialogOverlay from './alert-dialog-overlay.svelte';
+  import { cn } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    portalProps,
+    children,
+    ...restProps
+  }: WithoutChildrenOrChild<AlertDialogPrimitive.ContentProps> & {
+    portalProps?: AlertDialogPrimitive.PortalProps;
+    children: Snippet;
+  } = $props();
+</script>
+
+<AlertDialogPrimitive.Portal {...portalProps}>
+  <AlertDialogOverlay />
+  <AlertDialogPrimitive.Content
+    bind:ref
+    class={cn(
+      'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 sm:rounded-lg',
+      className
+    )}
+    {...restProps}
+  >
+    {@render children?.()}
+  </AlertDialogPrimitive.Content>
+</AlertDialogPrimitive.Portal>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-description.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-description.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import { AlertDialog as AlertDialogPrimitive } from 'bits-ui';
+  import { cn } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    ...restProps
+  }: AlertDialogPrimitive.DescriptionProps = $props();
+</script>
+
+<AlertDialogPrimitive.Description
+  bind:ref
+  class={cn('text-muted-foreground text-sm', className)}
+  {...restProps}
+/>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-footer.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-footer.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import type { HTMLAttributes } from 'svelte/elements';
+  import type { WithElementRef } from 'bits-ui';
+  import { cn } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+  bind:this={ref}
+  class={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)}
+  {...restProps}
+>
+  {@render children?.()}
+</div>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-header.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-header.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import type { HTMLAttributes } from 'svelte/elements';
+  import type { WithElementRef } from 'bits-ui';
+  import { cn } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+  bind:this={ref}
+  class={cn('flex flex-col space-y-2 text-center sm:text-left', className)}
+  {...restProps}
+>
+  {@render children?.()}
+</div>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-overlay.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-overlay.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import { AlertDialog as AlertDialogPrimitive } from 'bits-ui';
+  import { cn } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    ...restProps
+  }: AlertDialogPrimitive.OverlayProps = $props();
+</script>
+
+<AlertDialogPrimitive.Overlay
+  bind:ref
+  class={cn(
+    'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80',
+    className
+  )}
+  {...restProps}
+/>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-title.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-title.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import { AlertDialog as AlertDialogPrimitive } from 'bits-ui';
+  import { cn } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    ...restProps
+  }: AlertDialogPrimitive.TitleProps = $props();
+</script>
+
+<AlertDialogPrimitive.Title
+  bind:ref
+  class={cn('text-foreground text-lg font-semibold', className)}
+  {...restProps}
+/>

--- a/src/lib/components/ui/alert-dialog/index.ts
+++ b/src/lib/components/ui/alert-dialog/index.ts
@@ -1,0 +1,40 @@
+import { AlertDialog as AlertDialogPrimitive } from 'bits-ui';
+
+import Overlay from './alert-dialog-overlay.svelte';
+import Content from './alert-dialog-content.svelte';
+import Header from './alert-dialog-header.svelte';
+import Footer from './alert-dialog-footer.svelte';
+import Title from './alert-dialog-title.svelte';
+import Description from './alert-dialog-description.svelte';
+import Action from './alert-dialog-action.svelte';
+import Cancel from './alert-dialog-cancel.svelte';
+
+const Root = AlertDialogPrimitive.Root;
+const Trigger = AlertDialogPrimitive.Trigger;
+const Portal = AlertDialogPrimitive.Portal;
+
+export {
+  Root,
+  Trigger,
+  Portal,
+  Overlay,
+  Content,
+  Header,
+  Footer,
+  Title,
+  Description,
+  Action,
+  Cancel,
+  //
+  Root as AlertDialog,
+  Trigger as AlertDialogTrigger,
+  Portal as AlertDialogPortal,
+  Overlay as AlertDialogOverlay,
+  Content as AlertDialogContent,
+  Header as AlertDialogHeader,
+  Footer as AlertDialogFooter,
+  Title as AlertDialogTitle,
+  Description as AlertDialogDescription,
+  Action as AlertDialogAction,
+  Cancel as AlertDialogCancel,
+};

--- a/src/routes/series/[id]/edit/+page.svelte
+++ b/src/routes/series/[id]/edit/+page.svelte
@@ -11,12 +11,15 @@
     CardTitle,
   } from '$lib/components/ui/card';
   import { Input } from '$lib/components/ui/input';
-  import { ChevronLeft, Image as ImageIcon, RotateCcw } from '$lib/lucide';
+  import * as AlertDialog from '$lib/components/ui/alert-dialog';
+  import { ChevronLeft, Image as ImageIcon, RotateCcw, Trash2 } from '$lib/lucide';
 
   let show: Show | null = $state(null);
   let loading = $state(true);
   let saving = $state(false);
   let busyPoster = $state(false);
+  let deleting = $state(false);
+  let confirmDeleteOpen = $state(false);
   let error = $state<string | null>(null);
 
   let titleDraft = $state('');
@@ -129,6 +132,24 @@
       error = String(caught);
     } finally {
       busyPoster = false;
+    }
+  }
+
+  async function deleteSeries() {
+    if (!show) {
+      return;
+    }
+
+    deleting = true;
+    error = null;
+    try {
+      await api.deleteShow(show.id);
+      confirmDeleteOpen = false;
+      await goto('/series');
+    } catch (caught) {
+      error = String(caught);
+    } finally {
+      deleting = false;
     }
   }
 </script>
@@ -251,6 +272,46 @@
             language, genres.
           </CardDescription>
         </CardHeader>
+      </Card>
+
+      <Card class="border-destructive/30">
+        <CardHeader>
+          <CardTitle>Danger zone</CardTitle>
+          <CardDescription>
+            Remove this series from your library. Files on disk are not deleted.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <AlertDialog.Root bind:open={confirmDeleteOpen}>
+            <AlertDialog.Trigger
+              class="inline-flex h-9 items-center justify-center gap-2 whitespace-nowrap rounded-md bg-destructive px-4 py-2 text-sm font-medium text-destructive-foreground shadow-sm transition-colors hover:bg-destructive/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
+            >
+              <Trash2 class="size-4" />
+              Delete series
+            </AlertDialog.Trigger>
+            <AlertDialog.Content>
+              <AlertDialog.Header>
+                <AlertDialog.Title>Delete this series?</AlertDialog.Title>
+                <AlertDialog.Description>
+                  {show.title} and its {show.episode_count} episode {show.episode_count === 1
+                    ? 'entry'
+                    : 'entries'} will be removed from the library. The files on your disk are not
+                  touched.
+                </AlertDialog.Description>
+              </AlertDialog.Header>
+              <AlertDialog.Footer>
+                <AlertDialog.Cancel disabled={deleting}>Cancel</AlertDialog.Cancel>
+                <AlertDialog.Action
+                  variant="destructive"
+                  onclick={deleteSeries}
+                  disabled={deleting}
+                >
+                  {deleting ? 'Deleting…' : 'Delete'}
+                </AlertDialog.Action>
+              </AlertDialog.Footer>
+            </AlertDialog.Content>
+          </AlertDialog.Root>
+        </CardContent>
       </Card>
 
       <div class="flex justify-end gap-2">


### PR DESCRIPTION
## Summary
- Add a destructive "Danger zone" action on the series edit page that removes a series and its episodes from the database. Files on disk are not touched.
- New Tauri command `delete_show` backed by a transactional `queries::delete_show` that also clears orphan `watch_history` rows for the show's episodes.
- Clean up manual posters stored under `<app_data>/posters/`; never touch auto posters (which live inside the user's media folder).
- Add a `shadcn-svelte` `AlertDialog` wrapper around `bits-ui` so destructive confirmations get a proper centered modal instead of reusing the side `Sheet`.

## Why
After a rescan, a previously merged series can come back as a duplicate alongside the merged-into series. The user needs a way to remove the duplicate row without deleting any media on disk. Movies are out of scope for this PR — same shape, follow-up.

## Test plan
- [ ] Open a duplicate series → Edit details → scroll to "Danger zone" → click "Delete series" → confirm in the dialog.
- [ ] After confirm, the page navigates back to `/series` and the series is gone from the grid.
- [ ] In SQLite, `shows`, `episodes` (cascaded), and `watch_history` (episode rows) are all clean for the deleted show.
- [ ] The episode files on disk are still present (verify with `ls`).
- [ ] If the deleted show had a manual poster under `<app_data>/posters/`, that file is gone; an auto poster sitting in the library folder is untouched.
- [ ] Cancel button in the dialog dismisses without deleting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)