### PR TITLE
Edit episode titles inline on the series detail page

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -162,6 +162,21 @@ pub async fn update_movie_metadata(
 }
 
 #[tauri::command]
+pub async fn update_episode_title(
+    db: State<'_, Db>,
+    id: i64,
+    title: String,
+) -> AppResult<Episode> {
+    let trimmed = title.trim();
+    if trimmed.is_empty() {
+        return Err(AppError::Other("episode title cannot be empty".to_string()));
+    }
+
+    queries::update_episode_title(&db, id, trimmed).await?;
+    queries::get_episode(&db, id).await
+}
+
+#[tauri::command]
 pub async fn merge_shows(
     db: State<'_, Db>,
     target_id: i64,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -42,6 +42,7 @@ pub fn run() {
             commands::play_episode,
             commands::update_show_metadata,
             commands::update_movie_metadata,
+            commands::update_episode_title,
             commands::merge_shows,
             commands::delete_show,
             commands::set_show_poster_from_file,

--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -284,6 +284,20 @@ async fn reset_poster_row(pool: &SqlitePool, table: &str, id: i64) -> AppResult<
     Ok(())
 }
 
+pub async fn update_episode_title(pool: &SqlitePool, id: i64, title: &str) -> AppResult<()> {
+    let result = sqlx::query("UPDATE episodes SET title = ?1 WHERE id = ?2")
+        .bind(title)
+        .bind(id)
+        .execute(pool)
+        .await?;
+
+    if result.rows_affected() == 0 {
+        return Err(AppError::MediaNotFound(id));
+    }
+
+    Ok(())
+}
+
 /// Reassigns every episode of `source_id` to `target_id` and deletes
 /// `source_id`. If both shows have an episode with the same
 /// `(season, episode)` the merge is rejected — the conflicting pairs are

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -121,6 +121,8 @@ export const api = {
     invoke<Show>('update_show_metadata', { id, ...patch }),
   updateMovieMetadata: (id: number, patch: MetadataPatch) =>
     invoke<Movie>('update_movie_metadata', { id, ...patch }),
+  updateEpisodeTitle: (id: number, title: string) =>
+    invoke<Episode>('update_episode_title', { id, title }),
   mergeShows: (targetId: number, sourceId: number) =>
     invoke<MergeOutcome>('merge_shows', { targetId, sourceId }),
   deleteShow: (id: number) => invoke<void>('delete_show', { id }),

--- a/src/lib/components/EpisodeTitleEditor.svelte
+++ b/src/lib/components/EpisodeTitleEditor.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+  import { Pencil } from '$lib/lucide';
+
+  type Props = {
+    title: string;
+    onSave: (next: string) => Promise<void> | void;
+  };
+
+  let { title, onSave }: Props = $props();
+
+  let editing = $state(false);
+  let draft = $state('');
+  let saving = $state(false);
+
+  function startEdit() {
+    if (editing) {
+      return;
+    }
+    draft = title;
+    editing = true;
+  }
+
+  function cancelEdit() {
+    editing = false;
+    draft = '';
+  }
+
+  async function commitEdit() {
+    const next = draft.trim();
+    if (next.length === 0 || next === title) {
+      cancelEdit();
+      return;
+    }
+
+    saving = true;
+    try {
+      await onSave(next);
+    } finally {
+      saving = false;
+      editing = false;
+      draft = '';
+    }
+  }
+
+  function autoFocus(node: HTMLInputElement) {
+    node.focus();
+    node.select();
+  }
+</script>
+
+{#if editing}
+  <input
+    use:autoFocus
+    bind:value={draft}
+    disabled={saving}
+    onblur={commitEdit}
+    onkeydown={(event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        void commitEdit();
+      } else if (event.key === 'Escape') {
+        event.preventDefault();
+        cancelEdit();
+      }
+    }}
+    class="w-full rounded-md border border-primary/60 bg-background/60 px-2 py-1 text-sm font-medium text-foreground outline-none"
+  />
+{:else}
+  <button
+    type="button"
+    onclick={startEdit}
+    aria-label="Edit episode title"
+    class="group/title -mx-1 flex min-w-0 items-center gap-2 rounded-md px-1 py-0.5 text-left transition hover:bg-background/30"
+  >
+    <span class="truncate font-medium">{title}</span>
+    <Pencil
+      class="size-3.5 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover/title:opacity-100"
+    />
+  </button>
+{/if}

--- a/src/routes/series/[id]/+page.svelte
+++ b/src/routes/series/[id]/+page.svelte
@@ -8,6 +8,7 @@
     type Season,
     type Show,
   } from '$lib/api';
+  import EpisodeTitleEditor from '$lib/components/EpisodeTitleEditor.svelte';
   import HeroBanner from '$lib/components/HeroBanner.svelte';
   import MergeShowSheet from '$lib/components/MergeShowSheet.svelte';
   import { Check, Circle, GitMerge, Pencil, Play } from '$lib/lucide';
@@ -102,6 +103,24 @@
         poster_path: updated.poster_path,
         poster_origin: updated.poster_origin,
       };
+    } catch (caught) {
+      error = String(caught);
+    }
+  }
+
+  async function saveEpisodeTitle(episodeId: number, nextTitle: string) {
+    try {
+      const updated = await api.updateEpisodeTitle(episodeId, nextTitle);
+
+      for (const season of seasons) {
+        const episode = season.episodes.find((candidate) => candidate.id === episodeId);
+        if (!episode) {
+          continue;
+        }
+
+        episode.title = updated.title;
+        return;
+      }
     } catch (caught) {
       error = String(caught);
     }
@@ -218,7 +237,12 @@
             </div>
             <div class="min-w-0 flex-1">
               <div class="flex items-center gap-2">
-                <span class="truncate font-medium">{ep.title}</span>
+                <div class="min-w-0 flex-1">
+                  <EpisodeTitleEditor
+                    title={ep.title}
+                    onSave={(next) => saveEpisodeTitle(ep.id, next)}
+                  />
+                </div>
                 {#if ep.watched}
                   <Check class="size-4 shrink-0 text-emerald-400" />
                 {/if}


### PR DESCRIPTION
## Summary
- Click an episode title on `/series/[id]` to swap it for an input. Enter saves, Escape cancels, blur saves.
- New `update_episode_title` Tauri command + `api.updateEpisodeTitle` returning the updated `Episode`.
- Reuses the inline-edit pattern PR #13 introduced on `HeroBanner`, extracted into a small `EpisodeTitleEditor` component scaled for episode rows.

## Why
Scanner-derived titles are often generic (``Episode 1``) or have filename artifacts the user wants to clean up. Editing should happen where the user reads the title, not behind a navigation.

## Test plan
- [ ] Open a series with a poorly-named episode → hover the title → pencil appears → click → input takes focus with the existing title selected.
- [ ] Type a new title → Enter → row updates, no flash, the "Next up" subtitle updates if the edited episode was next up.
- [ ] Re-open the row, blank the field, blur → no API call, no change.
- [ ] Re-open the row, keep the value the same, blur → no API call, no change.
- [ ] Escape after typing → reverts to the saved title.
- [ ] Reload the page → the new title persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)