### PR TITLE
Fix hover ring/scale getting clipped on home screen card rows

### DIFF
--- a/src/lib/components/MediaRow.svelte
+++ b/src/lib/components/MediaRow.svelte
@@ -49,7 +49,7 @@
 
   <div
     bind:this={scroller}
-    class="no-scrollbar flex gap-4 overflow-x-auto scroll-smooth px-6 pb-2"
+    class="no-scrollbar flex gap-4 overflow-x-auto overflow-y-visible scroll-smooth px-6 py-2"
   >
     {@render children()}
   </div>


### PR DESCRIPTION
## Summary
- Change `MediaRow.svelte`'s scroller from `overflow-x-auto pb-2` to `overflow-x-auto overflow-y-visible py-2` so the hover ring and 1.03 scale on cards aren't clipped at the top edge.

## Why
Per CSS spec, setting `overflow-x` to `auto` forces `overflow-y` to compute to `auto` as well. The hovered card's ring extends above the row's content box and was getting cut off. Adding `overflow-y-visible` restores spilling, and symmetric `py-2` gives the top edge the same breathing room the bottom already had via `pb-2`.

## Test plan
- [ ] Open the home screen, hover any card in any row — the ring/scale renders fully on all four sides, not clipped at the top.
- [ ] Use the chevron buttons to scroll the row horizontally — still works.
- [ ] No vertical scrollbar appears on the row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)