### PR TITLE
Replace native Settings select with shadcn-svelte Select

### DIFF
--- a/src/lib/components/ui/select/index.ts
+++ b/src/lib/components/ui/select/index.ts
@@ -1,0 +1,34 @@
+import { Select as SelectPrimitive } from 'bits-ui';
+
+import Trigger from './select-trigger.svelte';
+import Content from './select-content.svelte';
+import Item from './select-item.svelte';
+import Group from './select-group.svelte';
+import Label from './select-label.svelte';
+import ScrollUpButton from './select-scroll-up-button.svelte';
+import ScrollDownButton from './select-scroll-down-button.svelte';
+
+const Root = SelectPrimitive.Root;
+const Portal = SelectPrimitive.Portal;
+
+export {
+  Root,
+  Portal,
+  Trigger,
+  Content,
+  Item,
+  Group,
+  Label,
+  ScrollUpButton,
+  ScrollDownButton,
+  //
+  Root as Select,
+  Portal as SelectPortal,
+  Trigger as SelectTrigger,
+  Content as SelectContent,
+  Item as SelectItem,
+  Group as SelectGroup,
+  Label as SelectLabel,
+  ScrollUpButton as SelectScrollUpButton,
+  ScrollDownButton as SelectScrollDownButton,
+};

--- a/src/lib/components/ui/select/select-content.svelte
+++ b/src/lib/components/ui/select/select-content.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import { Select as SelectPrimitive, type WithoutChildrenOrChild } from 'bits-ui';
+  import type { Snippet } from 'svelte';
+  import SelectScrollUpButton from './select-scroll-up-button.svelte';
+  import SelectScrollDownButton from './select-scroll-down-button.svelte';
+  import { cn } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    sideOffset = 4,
+    portalProps,
+    children,
+    ...restProps
+  }: WithoutChildrenOrChild<SelectPrimitive.ContentProps> & {
+    portalProps?: SelectPrimitive.PortalProps;
+    children: Snippet;
+  } = $props();
+</script>
+
+<SelectPrimitive.Portal {...portalProps}>
+  <SelectPrimitive.Content
+    bind:ref
+    {sideOffset}
+    class={cn(
+      'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border shadow-md',
+      className
+    )}
+    {...restProps}
+  >
+    <SelectScrollUpButton />
+    <SelectPrimitive.Viewport
+      class="h-[var(--bits-select-anchor-height)] w-full min-w-[var(--bits-select-anchor-width)] p-1"
+    >
+      {@render children?.()}
+    </SelectPrimitive.Viewport>
+    <SelectScrollDownButton />
+  </SelectPrimitive.Content>
+</SelectPrimitive.Portal>

--- a/src/lib/components/ui/select/select-group.svelte
+++ b/src/lib/components/ui/select/select-group.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import { Select as SelectPrimitive } from 'bits-ui';
+  import { cn } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    ...restProps
+  }: SelectPrimitive.GroupProps = $props();
+</script>
+
+<SelectPrimitive.Group bind:ref class={cn(className)} {...restProps} />

--- a/src/lib/components/ui/select/select-item.svelte
+++ b/src/lib/components/ui/select/select-item.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  import { Select as SelectPrimitive, type WithoutChild } from 'bits-ui';
+  import Check from '@lucide/svelte/icons/check';
+  import type { Snippet } from 'svelte';
+  import { cn } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    value,
+    label,
+    children: childrenProp,
+    ...restProps
+  }: WithoutChild<SelectPrimitive.ItemProps> & {
+    children?: Snippet<[{ selected: boolean; highlighted: boolean }]>;
+  } = $props();
+</script>
+
+<SelectPrimitive.Item
+  bind:ref
+  {value}
+  {label}
+  class={cn(
+    'data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+    className
+  )}
+  {...restProps}
+>
+  {#snippet children({ selected, highlighted })}
+    <span class="absolute left-2 flex size-3.5 items-center justify-center">
+      {#if selected}
+        <Check class="size-4" />
+      {/if}
+    </span>
+    {#if childrenProp}
+      {@render childrenProp({ selected, highlighted })}
+    {:else}
+      {label ?? value}
+    {/if}
+  {/snippet}
+</SelectPrimitive.Item>

--- a/src/lib/components/ui/select/select-label.svelte
+++ b/src/lib/components/ui/select/select-label.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import { Select as SelectPrimitive } from 'bits-ui';
+  import { cn } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    ...restProps
+  }: SelectPrimitive.GroupHeadingProps = $props();
+</script>
+
+<SelectPrimitive.GroupHeading
+  bind:ref
+  class={cn('px-2 py-1.5 text-sm font-semibold', className)}
+  {...restProps}
+/>

--- a/src/lib/components/ui/select/select-scroll-down-button.svelte
+++ b/src/lib/components/ui/select/select-scroll-down-button.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import { Select as SelectPrimitive } from 'bits-ui';
+  import ChevronDown from '@lucide/svelte/icons/chevron-down';
+  import { cn } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    ...restProps
+  }: SelectPrimitive.ScrollDownButtonProps = $props();
+</script>
+
+<SelectPrimitive.ScrollDownButton
+  bind:ref
+  class={cn('flex cursor-default items-center justify-center py-1', className)}
+  {...restProps}
+>
+  <ChevronDown class="size-4" />
+</SelectPrimitive.ScrollDownButton>

--- a/src/lib/components/ui/select/select-scroll-up-button.svelte
+++ b/src/lib/components/ui/select/select-scroll-up-button.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import { Select as SelectPrimitive } from 'bits-ui';
+  import ChevronUp from '@lucide/svelte/icons/chevron-up';
+  import { cn } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    ...restProps
+  }: SelectPrimitive.ScrollUpButtonProps = $props();
+</script>
+
+<SelectPrimitive.ScrollUpButton
+  bind:ref
+  class={cn('flex cursor-default items-center justify-center py-1', className)}
+  {...restProps}
+>
+  <ChevronUp class="size-4" />
+</SelectPrimitive.ScrollUpButton>

--- a/src/lib/components/ui/select/select-trigger.svelte
+++ b/src/lib/components/ui/select/select-trigger.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import { Select as SelectPrimitive } from 'bits-ui';
+  import ChevronDown from '@lucide/svelte/icons/chevron-down';
+  import { cn } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    ...restProps
+  }: SelectPrimitive.TriggerProps = $props();
+</script>
+
+<SelectPrimitive.Trigger
+  bind:ref
+  class={cn(
+    'border-input bg-background ring-offset-background placeholder:text-muted-foreground focus:ring-ring data-[placeholder]:text-muted-foreground flex h-9 w-full items-center justify-between gap-2 rounded-md border px-3 py-2 text-sm shadow-sm transition-colors focus:outline-none focus:ring-1 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
+    className
+  )}
+  {...restProps}
+>
+  {@render children?.()}
+  <ChevronDown class="size-4 shrink-0 opacity-50" />
+</SelectPrimitive.Trigger>

--- a/src/routes/settings/libraries/+page.svelte
+++ b/src/routes/settings/libraries/+page.svelte
@@ -1,11 +1,20 @@
 <script lang="ts">
   import { api, type Library, type LibraryKind, type ScanReport } from '$lib/api';
+  import * as Select from '$lib/components/ui/select';
   import { FolderPlus, RefreshCw, Trash2 } from '$lib/lucide';
 
   let libraries: Library[] = $state([]);
   let loading = $state(true);
   let busy = $state(false);
   let kind: LibraryKind = $state('mixed');
+
+  const kindLabels: Record<LibraryKind, string> = {
+    mixed: 'Auto-detect',
+    movies: 'Movies only',
+    series: 'Series only',
+  };
+
+  const selectedKindLabel = $derived(kindLabels[kind]);
   let mpvOk = $state<boolean | null>(null);
   let lastReport: ScanReport | null = $state(null);
   let error = $state<string | null>(null);
@@ -94,17 +103,25 @@
       Add a folder
     </h2>
     <div class="flex flex-wrap items-center gap-3">
-      <label class="flex items-center gap-2 text-sm">
+      <div class="flex items-center gap-2 text-sm">
         <span class="text-muted-foreground">Treat as:</span>
-        <select
-          bind:value={kind}
-          class="rounded-md border border-border bg-background px-3 py-1.5 text-sm focus:border-primary focus:outline-none"
+        <Select.Root
+          type="single"
+          value={kind}
+          onValueChange={(value) => {
+            kind = value as LibraryKind;
+          }}
         >
-          <option value="mixed">Auto-detect</option>
-          <option value="movies">Movies only</option>
-          <option value="series">Series only</option>
-        </select>
-      </label>
+          <Select.Trigger class="w-[170px]" aria-label="Library kind">
+            {selectedKindLabel}
+          </Select.Trigger>
+          <Select.Content>
+            <Select.Item value="mixed" label="Auto-detect">Auto-detect</Select.Item>
+            <Select.Item value="movies" label="Movies only">Movies only</Select.Item>
+            <Select.Item value="series" label="Series only">Series only</Select.Item>
+          </Select.Content>
+        </Select.Root>
+      </div>
       <button
         type="button"
         onclick={add}


### PR DESCRIPTION
## Summary
- New `src/lib/components/ui/select/` shadcn-svelte wrapper around `bits-ui` Select (mirrors the existing `sheet/` and `alert-dialog/` wrappers).
- Replace the native `<select>` on Settings → Libraries with the new `Select.*` markup. The "Treat as" dropdown now has a proper themed trigger with a right-aligned chevron, a popover that matches the dark UI, and keyboard nav (arrow keys, typeahead, Escape).

## Why
The native ``<select>`` rendered the OS chevron unaligned and opened a non-themed popup that clashed with the rest of the app. Switching to the same primitive family the rest of the UI uses fixes both and gives future selects a ready wrapper.

## Test plan
- [ ] Go to Settings → Libraries. The "Treat as" trigger sits at the same height as the "Pick folder" / "Rescan all" buttons, with a half-opacity chevron flush against the right padding.
- [ ] Click the trigger → popover opens with dark theme, rounded corners, item hover highlight, and a check next to the current selection.
- [ ] Arrow keys move highlight; Enter selects; Escape closes; typing "M" jumps to "Movies only".
- [ ] After picking "Movies only" and adding a folder, ``api.addLibrary(path, 'movies')`` is called (the new library row shows ``MOVIES``).

🤖 Generated with [Claude Code](https://claude.com/claude-code)