### PR TITLE
Fix year-input crash on edit pages

### DIFF
--- a/src/routes/films/[id]/edit/+page.svelte
+++ b/src/routes/films/[id]/edit/+page.svelte
@@ -176,7 +176,7 @@
           <label class="flex flex-col gap-1.5 text-sm">
             <span class="font-medium">Year</span>
             <Input
-              type="number"
+              type="text"
               bind:value={yearDraft}
               placeholder="e.g. 1999"
               inputmode="numeric"

--- a/src/routes/series/[id]/edit/+page.svelte
+++ b/src/routes/series/[id]/edit/+page.svelte
@@ -197,7 +197,7 @@
           <label class="flex flex-col gap-1.5 text-sm">
             <span class="font-medium">Year</span>
             <Input
-              type="number"
+              type="text"
               bind:value={yearDraft}
               placeholder="e.g. 2008"
               inputmode="numeric"


### PR DESCRIPTION
## Summary
- Change the Year ``<Input>`` on both the series and films edit pages from ``type=\"number\"`` to ``type=\"text\"``. ``inputmode=\"numeric\"`` already provides the mobile/touch numeric keyboard, so the user-facing experience is unchanged.

## Why
Svelte 5's ``bind:value`` on ``type=\"number\"`` coerces the bound variable to ``number | undefined`` the moment the user types — so ``yearDraft`` (declared as a string) became a number, and the Save handler's ``yearDraft.trim()`` threw ``TypeError``. The user got a stringified error instead of the save going through. The code-review pass caught this with high confidence.

## Test plan
- [ ] Open a series with a year prefilled → change the year → click Save → no error, the new year persists.
- [ ] Same on a movies edit page.
- [ ] Clear the year field entirely → Save → year is cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)