### PR TITLE
Metadata sync PR A: schema scaffolding, settings page, edit-lock

### DIFF
--- a/src-tauri/migrations/0003_metadata_sync.sql
+++ b/src-tauri/migrations/0003_metadata_sync.sql
@@ -1,0 +1,41 @@
+-- Adds the metadata sync columns on shows and movies plus the job-queue and
+-- app-settings tables. Pure ALTER TABLE ADD COLUMN + CREATE TABLE / INDEX,
+-- so no table rebuild is needed.
+
+ALTER TABLE shows  ADD COLUMN provider           TEXT;
+ALTER TABLE shows  ADD COLUMN provider_id        TEXT;
+ALTER TABLE shows  ADD COLUMN rating             REAL;
+ALTER TABLE shows  ADD COLUMN genres             TEXT;
+ALTER TABLE shows  ADD COLUMN top_cast           TEXT;
+ALTER TABLE shows  ADD COLUMN first_air_date     TEXT;
+ALTER TABLE shows  ADD COLUMN metadata_synced_at INTEGER;
+ALTER TABLE shows  ADD COLUMN metadata_locked    INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE movies ADD COLUMN provider           TEXT;
+ALTER TABLE movies ADD COLUMN provider_id        TEXT;
+ALTER TABLE movies ADD COLUMN rating             REAL;
+ALTER TABLE movies ADD COLUMN genres             TEXT;
+ALTER TABLE movies ADD COLUMN top_cast           TEXT;
+ALTER TABLE movies ADD COLUMN runtime_minutes    INTEGER;
+ALTER TABLE movies ADD COLUMN metadata_synced_at INTEGER;
+ALTER TABLE movies ADD COLUMN metadata_locked    INTEGER NOT NULL DEFAULT 0;
+
+CREATE UNIQUE INDEX idx_shows_provider
+    ON shows(provider, provider_id)  WHERE provider IS NOT NULL;
+CREATE UNIQUE INDEX idx_movies_provider
+    ON movies(provider, provider_id) WHERE provider IS NOT NULL;
+
+CREATE TABLE metadata_jobs (
+    kind            TEXT    NOT NULL,
+    media_id        INTEGER NOT NULL,
+    enqueued_at     INTEGER NOT NULL DEFAULT (strftime('%s','now')),
+    attempts        INTEGER NOT NULL DEFAULT 0,
+    last_error      TEXT,
+    next_attempt_at INTEGER NOT NULL DEFAULT (strftime('%s','now')),
+    PRIMARY KEY (kind, media_id)
+);
+
+CREATE TABLE IF NOT EXISTS app_settings (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -200,6 +200,28 @@ pub async fn delete_show(app: AppHandle, db: State<'_, Db>, id: i64) -> AppResul
     Ok(())
 }
 
+#[tauri::command]
+pub async fn get_tmdb_api_key(db: State<'_, Db>) -> AppResult<Option<String>> {
+    queries::get_app_setting(&db, "tmdb_api_key").await
+}
+
+#[tauri::command]
+pub async fn set_tmdb_api_key(db: State<'_, Db>, key: String) -> AppResult<()> {
+    let trimmed = key.trim();
+    if trimmed.is_empty() {
+        queries::delete_app_setting(&db, "tmdb_api_key").await
+    } else {
+        queries::set_app_setting(&db, "tmdb_api_key", trimmed).await
+    }
+}
+
+#[tauri::command]
+pub async fn metadata_status_counts(
+    db: State<'_, Db>,
+) -> AppResult<crate::models::MetadataStatusCounts> {
+    queries::metadata_status_counts(&db).await
+}
+
 /// Best-effort cleanup of a manual poster file. Only deletes the file when
 /// it sits inside our own `<app_data>/posters/` directory — any other path
 /// is ignored so a malformed `poster_path` can never remove user media.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -49,6 +49,9 @@ pub fn run() {
             commands::set_movie_poster_from_file,
             commands::reset_show_poster,
             commands::reset_movie_poster,
+            commands::get_tmdb_api_key,
+            commands::set_tmdb_api_key,
+            commands::metadata_status_counts,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -29,6 +29,14 @@ pub struct Movie {
     pub progress_seconds: i64,
     pub watched: bool,
     pub added_at: i64,
+    pub provider: Option<String>,
+    pub provider_id: Option<String>,
+    pub rating: Option<f64>,
+    pub genres: Option<String>,
+    pub top_cast: Option<String>,
+    pub runtime_minutes: Option<i64>,
+    pub metadata_synced_at: Option<i64>,
+    pub metadata_locked: i64,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, sqlx::FromRow)]
@@ -45,6 +53,14 @@ pub struct Show {
     pub episode_count: i64,
     pub watched_count: i64,
     pub added_at: i64,
+    pub provider: Option<String>,
+    pub provider_id: Option<String>,
+    pub rating: Option<f64>,
+    pub genres: Option<String>,
+    pub top_cast: Option<String>,
+    pub first_air_date: Option<String>,
+    pub metadata_synced_at: Option<i64>,
+    pub metadata_locked: i64,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, sqlx::FromRow)]
@@ -94,4 +110,13 @@ pub struct EpisodeRef {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct MergeOutcome {
     pub conflicts: Vec<EpisodeRef>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct MetadataStatusCounts {
+    pub pending: i64,
+    pub failed: i64,
+    pub auth_required: i64,
+    pub dead_letter: i64,
+    pub needs_review: i64,
 }

--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -47,7 +47,9 @@ const MOVIE_SELECT: &str = "
            m.duration_seconds,
            COALESCE(w.progress_seconds, 0) AS progress_seconds,
            COALESCE(w.watched, 0) AS watched,
-           m.added_at
+           m.added_at,
+           m.provider, m.provider_id, m.rating, m.genres, m.top_cast,
+           m.runtime_minutes, m.metadata_synced_at, m.metadata_locked
     FROM movies m
     LEFT JOIN watch_history w
       ON w.media_kind = 'movie' AND w.media_id = m.id
@@ -76,7 +78,9 @@ const SHOW_SELECT: &str = "
               LEFT JOIN watch_history w
                 ON w.media_kind = 'episode' AND w.media_id = e.id
              WHERE e.show_id = s.id AND COALESCE(w.watched, 0) = 1) AS watched_count,
-           s.added_at
+           s.added_at,
+           s.provider, s.provider_id, s.rating, s.genres, s.top_cast,
+           s.first_air_date, s.metadata_synced_at, s.metadata_locked
     FROM shows s
 ";
 
@@ -210,7 +214,10 @@ async fn update_metadata_row(
         return Ok(());
     }
 
-    let sql = format!("UPDATE {table} SET {} WHERE id = ?", assignments.join(", "));
+    let sql = format!(
+        "UPDATE {table} SET {}, metadata_locked = 1 WHERE id = ?",
+        assignments.join(", ")
+    );
 
     let mut query = sqlx::query(&sql);
     if let Some(value) = title {
@@ -437,4 +444,89 @@ pub async fn continue_watching(pool: &SqlitePool, limit: i64) -> AppResult<Vec<C
         }
     }
     Ok(out)
+}
+
+pub async fn get_app_setting(pool: &SqlitePool, key: &str) -> AppResult<Option<String>> {
+    let value: Option<String> =
+        sqlx::query_scalar("SELECT value FROM app_settings WHERE key = ?1")
+            .bind(key)
+            .fetch_optional(pool)
+            .await?;
+
+    Ok(value)
+}
+
+pub async fn set_app_setting(pool: &SqlitePool, key: &str, value: &str) -> AppResult<()> {
+    sqlx::query(
+        "INSERT INTO app_settings (key, value) VALUES (?1, ?2)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+    )
+    .bind(key)
+    .bind(value)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+pub async fn delete_app_setting(pool: &SqlitePool, key: &str) -> AppResult<()> {
+    sqlx::query("DELETE FROM app_settings WHERE key = ?1")
+        .bind(key)
+        .execute(pool)
+        .await?;
+
+    Ok(())
+}
+
+pub async fn metadata_status_counts(
+    pool: &SqlitePool,
+) -> AppResult<crate::models::MetadataStatusCounts> {
+    let pending: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM metadata_jobs
+         WHERE attempts = 0 AND COALESCE(last_error, '') <> 'auth_required'",
+    )
+    .fetch_one(pool)
+    .await?;
+
+    let failed: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM metadata_jobs
+         WHERE attempts > 0 AND attempts < 8
+           AND COALESCE(last_error, '') <> 'auth_required'",
+    )
+    .fetch_one(pool)
+    .await?;
+
+    let auth_required: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM metadata_jobs WHERE last_error = 'auth_required'",
+    )
+    .fetch_one(pool)
+    .await?;
+
+    let dead_letter: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM metadata_jobs WHERE attempts >= 8",
+    )
+    .fetch_one(pool)
+    .await?;
+
+    let needs_review: i64 = sqlx::query_scalar(
+        "SELECT
+             (SELECT COUNT(*) FROM shows
+                WHERE provider IS NULL
+                  AND NOT EXISTS (SELECT 1 FROM metadata_jobs j
+                                  WHERE j.kind = 'show' AND j.media_id = shows.id))
+           + (SELECT COUNT(*) FROM movies
+                WHERE provider IS NULL
+                  AND NOT EXISTS (SELECT 1 FROM metadata_jobs j
+                                  WHERE j.kind = 'movie' AND j.media_id = movies.id))",
+    )
+    .fetch_one(pool)
+    .await?;
+
+    Ok(crate::models::MetadataStatusCounts {
+        pending,
+        failed,
+        auth_required,
+        dead_letter,
+        needs_review,
+    })
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -23,6 +23,14 @@ export interface Movie {
   progress_seconds: number;
   watched: boolean;
   added_at: number;
+  provider: string | null;
+  provider_id: string | null;
+  rating: number | null;
+  genres: string | null;
+  top_cast: string | null;
+  runtime_minutes: number | null;
+  metadata_synced_at: number | null;
+  metadata_locked: number;
 }
 
 export interface Show {
@@ -38,6 +46,22 @@ export interface Show {
   episode_count: number;
   watched_count: number;
   added_at: number;
+  provider: string | null;
+  provider_id: string | null;
+  rating: number | null;
+  genres: string | null;
+  top_cast: string | null;
+  first_air_date: string | null;
+  metadata_synced_at: number | null;
+  metadata_locked: number;
+}
+
+export interface MetadataStatusCounts {
+  pending: number;
+  failed: number;
+  auth_required: number;
+  dead_letter: number;
+  needs_review: number;
 }
 
 export interface Episode {
@@ -132,6 +156,11 @@ export const api = {
     invoke<Movie>('set_movie_poster_from_file', { id, sourcePath }),
   resetShowPoster: (id: number) => invoke<Show>('reset_show_poster', { id }),
   resetMoviePoster: (id: number) => invoke<Movie>('reset_movie_poster', { id }),
+
+  getTmdbApiKey: () => invoke<string | null>('get_tmdb_api_key'),
+  setTmdbApiKey: (key: string) => invoke<void>('set_tmdb_api_key', { key }),
+  metadataStatusCounts: () =>
+    invoke<MetadataStatusCounts>('metadata_status_counts'),
 
   pickFolder: () =>
     open({

--- a/src/lib/components/TopNav.svelte
+++ b/src/lib/components/TopNav.svelte
@@ -37,9 +37,9 @@
 
   <div class="ml-auto flex items-center gap-2">
     <a
-      href="/settings/libraries"
+      href="/settings"
       class="inline-flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-      aria-label="Library settings"
+      aria-label="Settings"
     >
       <Settings class="size-4" />
     </a>

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import { ChevronRight } from '$lib/lucide';
+</script>
+
+<div class="mx-auto max-w-3xl px-6 py-8">
+  <h1 class="mb-6 text-3xl font-bold tracking-tight">Settings</h1>
+  <ul class="flex flex-col gap-2">
+    <li>
+      <a
+        href="/settings/libraries"
+        class="flex items-center justify-between rounded-md border border-border bg-card px-4 py-3 transition-colors hover:bg-accent"
+      >
+        <div>
+          <div class="font-medium">Libraries</div>
+          <div class="text-sm text-muted-foreground">
+            Folders Rustflix scans for movies and series.
+          </div>
+        </div>
+        <ChevronRight class="size-4 text-muted-foreground" />
+      </a>
+    </li>
+    <li>
+      <a
+        href="/settings/metadata"
+        class="flex items-center justify-between rounded-md border border-border bg-card px-4 py-3 transition-colors hover:bg-accent"
+      >
+        <div>
+          <div class="font-medium">Metadata</div>
+          <div class="text-sm text-muted-foreground">
+            TMDB integration for posters, cast, and overviews.
+          </div>
+        </div>
+        <ChevronRight class="size-4 text-muted-foreground" />
+      </a>
+    </li>
+  </ul>
+</div>

--- a/src/routes/settings/metadata/+page.svelte
+++ b/src/routes/settings/metadata/+page.svelte
@@ -1,0 +1,134 @@
+<script lang="ts">
+  import { api, type MetadataStatusCounts } from '$lib/api';
+  import { Button } from '$lib/components/ui/button';
+  import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+  } from '$lib/components/ui/card';
+  import { Input } from '$lib/components/ui/input';
+
+  let keyDraft = $state('');
+  let savedKey = $state<string | null>(null);
+  let saving = $state(false);
+  let counts = $state<MetadataStatusCounts | null>(null);
+  let error = $state<string | null>(null);
+
+  $effect(() => {
+    void load();
+  });
+
+  async function load() {
+    try {
+      const [keyResult, countsResult] = await Promise.all([
+        api.getTmdbApiKey(),
+        api.metadataStatusCounts(),
+      ]);
+      savedKey = keyResult;
+      counts = countsResult;
+      keyDraft = savedKey ?? '';
+    } catch (caught) {
+      error = String(caught);
+    }
+  }
+
+  async function saveKey() {
+    saving = true;
+    error = null;
+    try {
+      await api.setTmdbApiKey(keyDraft);
+      const trimmed = keyDraft.trim();
+      savedKey = trimmed.length === 0 ? null : trimmed;
+    } catch (caught) {
+      error = String(caught);
+    } finally {
+      saving = false;
+    }
+  }
+</script>
+
+<div class="mx-auto max-w-3xl px-6 py-8">
+  <header class="mb-6">
+    <h1 class="text-3xl font-bold tracking-tight">Metadata</h1>
+    <p class="text-sm text-muted-foreground">
+      Rustflix can fetch posters, overviews, genres, ratings, and cast from TMDB.
+    </p>
+  </header>
+
+  {#if error}
+    <div
+      class="mb-6 rounded-md border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive-foreground"
+    >
+      {error}
+    </div>
+  {/if}
+
+  <div class="flex flex-col gap-6">
+    <Card>
+      <CardHeader>
+        <CardTitle>TMDB API key</CardTitle>
+        <CardDescription>
+          Sign up at <a class="underline" href="https://www.themoviedb.org/settings/api">themoviedb.org</a>
+          and paste your v3 API key here. Without a key, metadata sync is paused.
+        </CardDescription>
+      </CardHeader>
+      <CardContent class="flex flex-col gap-3">
+        <Input
+          bind:value={keyDraft}
+          placeholder="Paste your TMDB v3 API key"
+          type="password"
+        />
+        <div class="flex items-center gap-3">
+          <Button onclick={saveKey} disabled={saving}>
+            {saving ? 'Saving…' : savedKey ? 'Update key' : 'Save key'}
+          </Button>
+          {#if savedKey}
+            <span class="text-xs text-muted-foreground">
+              A key is currently stored.
+            </span>
+          {/if}
+        </div>
+      </CardContent>
+    </Card>
+
+    <Card>
+      <CardHeader>
+        <CardTitle>Sync status</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {#if counts}
+          <ul class="grid grid-cols-2 gap-3 text-sm sm:grid-cols-5">
+            <li class="rounded-md border border-border bg-background px-3 py-2">
+              <div class="text-xs uppercase tracking-wide text-muted-foreground">Pending</div>
+              <div class="text-lg font-semibold">{counts.pending}</div>
+            </li>
+            <li class="rounded-md border border-border bg-background px-3 py-2">
+              <div class="text-xs uppercase tracking-wide text-muted-foreground">Failed</div>
+              <div class="text-lg font-semibold">{counts.failed}</div>
+            </li>
+            <li class="rounded-md border border-border bg-background px-3 py-2">
+              <div class="text-xs uppercase tracking-wide text-muted-foreground">Auth-paused</div>
+              <div class="text-lg font-semibold">{counts.auth_required}</div>
+            </li>
+            <li class="rounded-md border border-border bg-background px-3 py-2">
+              <div class="text-xs uppercase tracking-wide text-muted-foreground">Dead-letter</div>
+              <div class="text-lg font-semibold">{counts.dead_letter}</div>
+            </li>
+            <li class="rounded-md border border-border bg-background px-3 py-2">
+              <div class="text-xs uppercase tracking-wide text-muted-foreground">Needs review</div>
+              <div class="text-lg font-semibold">{counts.needs_review}</div>
+            </li>
+          </ul>
+        {:else}
+          <p class="text-sm text-muted-foreground">Loading…</p>
+        {/if}
+      </CardContent>
+    </Card>
+
+    <p class="text-xs text-muted-foreground">
+      Metadata powered by <a class="underline" href="https://www.themoviedb.org">TMDB</a>.
+    </p>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- Migration 0003_metadata_sync.sql introduces metadata columns on shows and movies, the metadata_jobs queue, and an app_settings key/value table.
- ``update_metadata_row`` flips ``metadata_locked = 1`` on any user text edit so future TMDB sync won't overwrite the user's changes.
- New ``get_tmdb_api_key``, ``set_tmdb_api_key``, ``metadata_status_counts`` Tauri commands.
- New Settings index page and Metadata settings page (API key input + counts panel). TopNav points to ``/settings``.

No network code, no new crates, no worker. Spec at ``docs/superpowers/specs/2026-05-24-metadata-sync-design.md``.

## Test plan
- [ ] Migration applies on a fresh DB and on a DB at migration 0002.
- [ ] Visit ``/settings/metadata``, save a key, reload — key persists.
- [ ] Edit a show title inline → ``SELECT metadata_locked FROM shows WHERE id = ?`` returns 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)