### PR TITLE
Metadata sync PR B: TMDB client, matcher, fetch_metadata_now

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -340,6 +340,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1195,8 +1201,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1206,9 +1214,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1531,6 +1541,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2012,6 +2023,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2142,7 +2159,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -2757,6 +2774,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2784,8 +2856,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2795,7 +2877,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2805,6 +2897,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2904,6 +3005,47 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
@@ -2937,7 +3079,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -2992,7 +3134,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
@@ -3023,6 +3165,7 @@ dependencies = [
  "libsqlite3-sys",
  "once_cell",
  "regex",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sqlx",
@@ -3032,6 +3175,7 @@ dependencies = [
  "tauri-plugin-updater",
  "thiserror 1.0.69",
  "tokio",
+ "unicode-normalization",
  "walkdir",
 ]
 
@@ -3080,6 +3224,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -3475,7 +3620,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3710,7 +3855,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.6",
  "rsa",
  "sha1",
  "sha2",
@@ -3747,7 +3892,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2",
@@ -3999,7 +4144,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4156,7 +4301,7 @@ dependencies = [
  "minisign-verify",
  "osakit",
  "percent-encoding",
- "reqwest",
+ "reqwest 0.13.3",
  "rustls",
  "semver",
  "serde",
@@ -4991,6 +5136,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
@@ -5019,6 +5177,16 @@ name = "web-sys"
 version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5085,6 +5253,15 @@ name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -34,3 +34,5 @@ thiserror = "1"
 regex = "1"
 once_cell = "1"
 tokio = { version = "1", features = ["sync", "rt", "rt-multi-thread", "macros", "time", "io-util", "net", "process", "fs"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "stream"] }
+unicode-normalization = "0.1"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -222,6 +222,134 @@ pub async fn metadata_status_counts(
     queries::metadata_status_counts(&db).await
 }
 
+#[tauri::command]
+pub async fn fetch_metadata_now(
+    app: AppHandle,
+    db: State<'_, Db>,
+    http: State<'_, reqwest::Client>,
+    kind: String,
+    id: i64,
+) -> AppResult<()> {
+    let api_key = queries::get_app_setting(&db, "tmdb_api_key")
+        .await?
+        .ok_or_else(|| AppError::Other("auth_required: no TMDB key configured".to_string()))?;
+
+    let app_data_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|error| AppError::Other(format!("app_data_dir: {error}")))?;
+    let posters_dir = app_data_dir.join("posters");
+
+    let outcome = match kind.as_str() {
+        "movie" => fetch_one_movie(&db, &http, &api_key, id).await?,
+        "show" => fetch_one_show(&db, &http, &api_key, id).await?,
+        other => {
+            return Err(AppError::Other(format!("unknown kind: {other}")));
+        }
+    };
+
+    if let Some((poster_url, dest_filename)) = outcome {
+        let dest = posters_dir.join(dest_filename);
+        crate::metadata::tmdb::download_poster(&http, &poster_url, &dest).await?;
+    }
+
+    Ok(())
+}
+
+async fn fetch_one_movie(
+    db: &Db,
+    http: &reqwest::Client,
+    api_key: &str,
+    movie_id: i64,
+) -> AppResult<Option<(String, String)>> {
+    let mut tx = db.begin().await?;
+
+    let locked: i64 = sqlx::query_scalar("SELECT metadata_locked FROM movies WHERE id = ?1")
+        .bind(movie_id)
+        .fetch_one(&mut *tx)
+        .await?;
+    if locked != 0 {
+        tx.rollback().await?;
+        return Ok(None);
+    }
+
+    let (title, year): (String, Option<i32>) =
+        sqlx::query_as("SELECT title, year FROM movies WHERE id = ?1")
+            .bind(movie_id)
+            .fetch_one(&mut *tx)
+            .await?;
+    tx.rollback().await?;
+
+    let candidates = crate::metadata::tmdb::search_movie(http, api_key, &title, year).await?;
+    let Some(pick) =
+        crate::metadata::matching::pick_confident_match(&title, year, &candidates)
+    else {
+        return Ok(None);
+    };
+
+    let details =
+        crate::metadata::tmdb::fetch_movie_details(http, api_key, &pick.provider_id).await?;
+
+    let mut tx = db.begin().await?;
+    let download_ext =
+        crate::metadata::apply::apply_movie_details(&mut *tx, movie_id, &details).await?;
+    tx.commit().await?;
+
+    Ok(match (download_ext, details.poster_path) {
+        (Some(extension), Some(poster_path)) => {
+            Some((poster_path, format!("movie-{movie_id}.{extension}")))
+        }
+        _ => None,
+    })
+}
+
+async fn fetch_one_show(
+    db: &Db,
+    http: &reqwest::Client,
+    api_key: &str,
+    show_id: i64,
+) -> AppResult<Option<(String, String)>> {
+    let mut tx = db.begin().await?;
+
+    let locked: i64 = sqlx::query_scalar("SELECT metadata_locked FROM shows WHERE id = ?1")
+        .bind(show_id)
+        .fetch_one(&mut *tx)
+        .await?;
+    if locked != 0 {
+        tx.rollback().await?;
+        return Ok(None);
+    }
+
+    let (title, year): (String, Option<i32>) =
+        sqlx::query_as("SELECT title, year FROM shows WHERE id = ?1")
+            .bind(show_id)
+            .fetch_one(&mut *tx)
+            .await?;
+    tx.rollback().await?;
+
+    let candidates = crate::metadata::tmdb::search_show(http, api_key, &title, year).await?;
+    let Some(pick) =
+        crate::metadata::matching::pick_confident_match(&title, year, &candidates)
+    else {
+        return Ok(None);
+    };
+
+    let details =
+        crate::metadata::tmdb::fetch_show_details(http, api_key, &pick.provider_id).await?;
+
+    let mut tx = db.begin().await?;
+    let download_ext =
+        crate::metadata::apply::apply_show_details(&mut *tx, show_id, &details).await?;
+    tx.commit().await?;
+
+    Ok(match (download_ext, details.poster_path) {
+        (Some(extension), Some(poster_path)) => {
+            Some((poster_path, format!("show-{show_id}.{extension}")))
+        }
+        _ => None,
+    })
+}
+
 /// Best-effort cleanup of a manual poster file. Only deletes the file when
 /// it sits inside our own `<app_data>/posters/` directory — any other path
 /// is ignored so a malformed `poster_path` can never remove user media.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod commands;
 mod db;
 mod error;
+mod metadata;
 mod models;
 mod player;
 mod queries;
@@ -22,6 +23,14 @@ pub fn run() {
             let pool = tauri::async_runtime::block_on(db::open(&app_data_dir))
                 .expect("failed to open database");
             app.manage(pool);
+
+            let http_client = reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(30))
+                .user_agent(concat!("rustflix/", env!("CARGO_PKG_VERSION")))
+                .build()
+                .expect("failed to build reqwest client");
+            app.manage(http_client);
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -52,6 +61,7 @@ pub fn run() {
             commands::get_tmdb_api_key,
             commands::set_tmdb_api_key,
             commands::metadata_status_counts,
+            commands::fetch_metadata_now,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/metadata/apply.rs
+++ b/src-tauri/src/metadata/apply.rs
@@ -1,0 +1,209 @@
+//! Pure DB writes for a fetched-and-matched TMDB payload. Called inside
+//! the worker's per-job transaction. Never overwrites a manual poster;
+//! the caller is responsible for checking metadata_locked beforehand.
+
+use sqlx::SqliteConnection;
+
+use crate::error::AppResult;
+use crate::metadata::tmdb::{TmdbCastMember, TmdbMovieDetails, TmdbShowDetails};
+
+/// Apply a fetched movie payload onto an existing `movies` row. Returns
+/// `Some(extension)` if the caller should download the poster into
+/// `movie-{id}.{extension}`, or `None` if the current row has a manual
+/// poster (must not be overwritten).
+pub async fn apply_movie_details(
+    conn: &mut SqliteConnection,
+    movie_id: i64,
+    details: &TmdbMovieDetails,
+) -> AppResult<Option<String>> {
+    let current_poster_origin: Option<String> =
+        sqlx::query_scalar("SELECT poster_origin FROM movies WHERE id = ?1")
+            .bind(movie_id)
+            .fetch_one(&mut *conn)
+            .await?;
+
+    let download_extension =
+        compute_poster_extension(current_poster_origin.as_deref(), details.poster_path.as_deref());
+
+    let genres_json = serde_json::to_string(
+        &details.genres.iter().map(|g| g.name.clone()).collect::<Vec<_>>(),
+    )
+    .unwrap_or_else(|_| "[]".to_string());
+    let cast_json = build_cast_json(details.credits.as_ref().map(|c| &c.cast));
+    let year = parse_year(details.release_date.as_deref());
+
+    if let Some(extension) = download_extension.as_ref() {
+        let local_path = format!("movie-{movie_id}.{extension}");
+        sqlx::query(
+            "UPDATE movies SET
+                 provider = 'tmdb',
+                 provider_id = ?1,
+                 overview = COALESCE(?2, overview),
+                 year = COALESCE(?3, year),
+                 rating = ?4,
+                 genres = ?5,
+                 top_cast = ?6,
+                 runtime_minutes = ?7,
+                 poster_path = ?8,
+                 poster_origin = 'tmdb',
+                 metadata_synced_at = strftime('%s','now')
+             WHERE id = ?9",
+        )
+        .bind(details.id.to_string())
+        .bind(details.overview.as_deref())
+        .bind(year)
+        .bind(details.vote_average)
+        .bind(&genres_json)
+        .bind(&cast_json)
+        .bind(details.runtime)
+        .bind(&local_path)
+        .bind(movie_id)
+        .execute(&mut *conn)
+        .await?;
+    } else {
+        sqlx::query(
+            "UPDATE movies SET
+                 provider = 'tmdb',
+                 provider_id = ?1,
+                 overview = COALESCE(?2, overview),
+                 year = COALESCE(?3, year),
+                 rating = ?4,
+                 genres = ?5,
+                 top_cast = ?6,
+                 runtime_minutes = ?7,
+                 metadata_synced_at = strftime('%s','now')
+             WHERE id = ?8",
+        )
+        .bind(details.id.to_string())
+        .bind(details.overview.as_deref())
+        .bind(year)
+        .bind(details.vote_average)
+        .bind(&genres_json)
+        .bind(&cast_json)
+        .bind(details.runtime)
+        .bind(movie_id)
+        .execute(&mut *conn)
+        .await?;
+    }
+
+    Ok(download_extension)
+}
+
+pub async fn apply_show_details(
+    conn: &mut SqliteConnection,
+    show_id: i64,
+    details: &TmdbShowDetails,
+) -> AppResult<Option<String>> {
+    let current_poster_origin: Option<String> =
+        sqlx::query_scalar("SELECT poster_origin FROM shows WHERE id = ?1")
+            .bind(show_id)
+            .fetch_one(&mut *conn)
+            .await?;
+
+    let download_extension =
+        compute_poster_extension(current_poster_origin.as_deref(), details.poster_path.as_deref());
+
+    let genres_json = serde_json::to_string(
+        &details.genres.iter().map(|g| g.name.clone()).collect::<Vec<_>>(),
+    )
+    .unwrap_or_else(|_| "[]".to_string());
+    let cast_json = build_cast_json(details.credits.as_ref().map(|c| &c.cast));
+    let year = parse_year(details.first_air_date.as_deref());
+
+    if let Some(extension) = download_extension.as_ref() {
+        let local_path = format!("show-{show_id}.{extension}");
+        sqlx::query(
+            "UPDATE shows SET
+                 provider = 'tmdb',
+                 provider_id = ?1,
+                 overview = COALESCE(?2, overview),
+                 year = COALESCE(?3, year),
+                 rating = ?4,
+                 genres = ?5,
+                 top_cast = ?6,
+                 first_air_date = ?7,
+                 poster_path = ?8,
+                 poster_origin = 'tmdb',
+                 metadata_synced_at = strftime('%s','now')
+             WHERE id = ?9",
+        )
+        .bind(details.id.to_string())
+        .bind(details.overview.as_deref())
+        .bind(year)
+        .bind(details.vote_average)
+        .bind(&genres_json)
+        .bind(&cast_json)
+        .bind(details.first_air_date.as_deref())
+        .bind(&local_path)
+        .bind(show_id)
+        .execute(&mut *conn)
+        .await?;
+    } else {
+        sqlx::query(
+            "UPDATE shows SET
+                 provider = 'tmdb',
+                 provider_id = ?1,
+                 overview = COALESCE(?2, overview),
+                 year = COALESCE(?3, year),
+                 rating = ?4,
+                 genres = ?5,
+                 top_cast = ?6,
+                 first_air_date = ?7,
+                 metadata_synced_at = strftime('%s','now')
+             WHERE id = ?8",
+        )
+        .bind(details.id.to_string())
+        .bind(details.overview.as_deref())
+        .bind(year)
+        .bind(details.vote_average)
+        .bind(&genres_json)
+        .bind(&cast_json)
+        .bind(details.first_air_date.as_deref())
+        .bind(show_id)
+        .execute(&mut *conn)
+        .await?;
+    }
+
+    Ok(download_extension)
+}
+
+fn build_cast_json(cast: Option<&Vec<TmdbCastMember>>) -> String {
+    let trimmed: Vec<_> = cast
+        .map(|members| members.iter().take(10).collect())
+        .unwrap_or_default();
+
+    let payload: Vec<serde_json::Value> = trimmed
+        .into_iter()
+        .map(|member| {
+            serde_json::json!({
+                "name": member.name,
+                "character": member.character,
+                "order": member.order,
+            })
+        })
+        .collect();
+
+    serde_json::to_string(&payload).unwrap_or_else(|_| "[]".to_string())
+}
+
+fn compute_poster_extension(
+    current_origin: Option<&str>,
+    poster_path: Option<&str>,
+) -> Option<String> {
+    if current_origin == Some("manual") {
+        return None;
+    }
+
+    let path = poster_path?;
+    let extension = path
+        .rsplit_once('.')
+        .map(|(_, ext)| ext)
+        .unwrap_or("jpg")
+        .to_lowercase();
+
+    Some(extension)
+}
+
+fn parse_year(date: Option<&str>) -> Option<i32> {
+    date.and_then(|d| d.get(0..4)).and_then(|year| year.parse().ok())
+}

--- a/src-tauri/src/metadata/matching.rs
+++ b/src-tauri/src/metadata/matching.rs
@@ -1,0 +1,177 @@
+//! Pure matching logic. Given a scanner-derived title + year and a list of
+//! provider search results, decide whether one is a confident match.
+
+use serde::{Deserialize, Serialize};
+use unicode_normalization::UnicodeNormalization;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MatchCandidate {
+    pub provider_id: String,
+    pub title: String,
+    pub year: Option<i32>,
+}
+
+/// Returns `Some(candidate)` only when query_title (after normalization)
+/// matches exactly one candidate whose year is within ±1 of query_year.
+/// Otherwise returns `None` so the caller can leave the item unlinked.
+pub fn pick_confident_match<'a>(
+    query_title: &str,
+    query_year: Option<i32>,
+    candidates: &'a [MatchCandidate],
+) -> Option<&'a MatchCandidate> {
+    let normalized_query = normalize(query_title);
+
+    let surviving: Vec<&MatchCandidate> = candidates
+        .iter()
+        .filter(|candidate| year_matches(candidate.year, query_year))
+        .filter(|candidate| normalize(&candidate.title) == normalized_query)
+        .collect();
+
+    if surviving.len() == 1 {
+        Some(surviving[0])
+    } else {
+        None
+    }
+}
+
+fn year_matches(candidate_year: Option<i32>, query_year: Option<i32>) -> bool {
+    match (candidate_year, query_year) {
+        (_, None) => true,
+        (None, Some(_)) => false,
+        (Some(a), Some(b)) => (a - b).abs() <= 1,
+    }
+}
+
+/// NFKD-fold, drop diacritics, strip "(US)" / "(2005)" disambiguators,
+/// drop leading article "the"/"a"/"an", lowercase, collapse whitespace.
+pub fn normalize(raw: &str) -> String {
+    let folded: String = raw.nfkd().filter(|character| character.is_ascii()).collect();
+    let lower = folded.to_lowercase();
+
+    let without_parens = strip_parenthetical(&lower);
+    let without_article = strip_leading_article(&without_parens);
+
+    without_article
+        .split_whitespace()
+        .filter(|token| !token.is_empty())
+        .collect::<Vec<&str>>()
+        .join(" ")
+}
+
+fn strip_parenthetical(input: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    let mut depth = 0i32;
+
+    for character in input.chars() {
+        match character {
+            '(' => depth += 1,
+            ')' => depth = (depth - 1).max(0),
+            _ if depth == 0 => output.push(character),
+            _ => {}
+        }
+    }
+
+    output
+}
+
+fn strip_leading_article(input: &str) -> String {
+    let trimmed = input.trim_start();
+    for article in ["the ", "a ", "an "] {
+        if let Some(rest) = trimmed.strip_prefix(article) {
+            return rest.to_string();
+        }
+    }
+    trimmed.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn candidate(id: &str, title: &str, year: Option<i32>) -> MatchCandidate {
+        MatchCandidate {
+            provider_id: id.to_string(),
+            title: title.to_string(),
+            year,
+        }
+    }
+
+    #[test]
+    fn unique_match_returns_it() {
+        let candidates = vec![candidate("1", "Breaking Bad", Some(2008))];
+        let picked = pick_confident_match("Breaking Bad", Some(2008), &candidates);
+        assert_eq!(picked.map(|m| m.provider_id.as_str()), Some("1"));
+    }
+
+    #[test]
+    fn the_office_us_vs_uk_resolved_by_year() {
+        let candidates = vec![
+            candidate("us", "The Office (US)", Some(2005)),
+            candidate("uk", "The Office", Some(2001)),
+        ];
+        let picked = pick_confident_match("The Office", Some(2005), &candidates);
+        assert_eq!(picked.map(|m| m.provider_id.as_str()), Some("us"));
+    }
+
+    #[test]
+    fn ambiguous_without_year_returns_none() {
+        let candidates = vec![
+            candidate("us", "The Office (US)", Some(2005)),
+            candidate("uk", "The Office", Some(2001)),
+        ];
+        let picked = pick_confident_match("The Office", None, &candidates);
+        assert!(picked.is_none());
+    }
+
+    #[test]
+    fn nfkd_fold_pokemon() {
+        let candidates = vec![candidate("1", "Pokemon", Some(1997))];
+        let picked = pick_confident_match("Pokémon", None, &candidates);
+        assert_eq!(picked.map(|m| m.provider_id.as_str()), Some("1"));
+    }
+
+    #[test]
+    fn year_plus_minus_one_accepted() {
+        let candidates = vec![candidate("1", "Foo", Some(2009))];
+        let picked = pick_confident_match("Foo", Some(2010), &candidates);
+        assert!(picked.is_some());
+    }
+
+    #[test]
+    fn year_more_than_one_off_rejected() {
+        let candidates = vec![candidate("1", "Foo", Some(2008))];
+        let picked = pick_confident_match("Foo", Some(2010), &candidates);
+        assert!(picked.is_none());
+    }
+
+    #[test]
+    fn two_matches_in_same_year_window_returns_none() {
+        let candidates = vec![
+            candidate("1", "Foo", Some(2010)),
+            candidate("2", "Foo", Some(2011)),
+        ];
+        let picked = pick_confident_match("Foo", Some(2010), &candidates);
+        assert!(picked.is_none());
+    }
+
+    #[test]
+    fn leading_article_stripped() {
+        let candidates = vec![candidate("1", "The Matrix", Some(1999))];
+        let picked = pick_confident_match("Matrix", Some(1999), &candidates);
+        assert!(picked.is_some());
+    }
+
+    #[test]
+    fn parenthetical_year_stripped() {
+        let candidates = vec![candidate("1", "Dune (2021)", Some(2021))];
+        let picked = pick_confident_match("Dune", Some(2021), &candidates);
+        assert!(picked.is_some());
+    }
+
+    #[test]
+    fn whitespace_collapsed() {
+        let candidates = vec![candidate("1", "Foo   Bar", Some(2010))];
+        let picked = pick_confident_match("Foo Bar", Some(2010), &candidates);
+        assert!(picked.is_some());
+    }
+}

--- a/src-tauri/src/metadata/mod.rs
+++ b/src-tauri/src/metadata/mod.rs
@@ -1,0 +1,6 @@
+//! Metadata sync subsystem. See
+//! docs/superpowers/specs/2026-05-24-metadata-sync-design.md.
+
+pub mod apply;
+pub mod matching;
+pub mod tmdb;

--- a/src-tauri/src/metadata/tmdb.rs
+++ b/src-tauri/src/metadata/tmdb.rs
@@ -1,0 +1,226 @@
+//! TMDB v3 client. Stays narrow: only the calls the worker needs.
+
+use std::path::Path;
+
+use reqwest::{Client, StatusCode};
+use serde::Deserialize;
+use tokio::io::AsyncWriteExt;
+
+use crate::error::{AppError, AppResult};
+use crate::metadata::matching::MatchCandidate;
+
+const API_BASE: &str = "https://api.themoviedb.org/3";
+const IMAGE_BASE: &str = "https://image.tmdb.org/t/p/w500";
+
+#[derive(Debug, Deserialize)]
+struct SearchEnvelope<T> {
+    results: Vec<T>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct TmdbMovieResult {
+    pub id: i64,
+    pub title: String,
+    pub release_date: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct TmdbShowResult {
+    pub id: i64,
+    pub name: String,
+    pub first_air_date: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TmdbCredits {
+    pub cast: Vec<TmdbCastMember>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct TmdbCastMember {
+    pub name: String,
+    pub character: Option<String>,
+    pub order: i64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TmdbGenre {
+    pub name: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TmdbMovieDetails {
+    pub id: i64,
+    #[allow(dead_code)]
+    pub title: String,
+    pub overview: Option<String>,
+    pub release_date: Option<String>,
+    pub vote_average: Option<f64>,
+    pub runtime: Option<i64>,
+    pub poster_path: Option<String>,
+    pub genres: Vec<TmdbGenre>,
+    pub credits: Option<TmdbCredits>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TmdbShowDetails {
+    pub id: i64,
+    #[allow(dead_code)]
+    pub name: String,
+    pub overview: Option<String>,
+    pub first_air_date: Option<String>,
+    pub vote_average: Option<f64>,
+    pub poster_path: Option<String>,
+    pub genres: Vec<TmdbGenre>,
+    pub credits: Option<TmdbCredits>,
+}
+
+pub async fn search_movie(
+    client: &Client,
+    api_key: &str,
+    title: &str,
+    year: Option<i32>,
+) -> AppResult<Vec<MatchCandidate>> {
+    let mut request = client
+        .get(format!("{API_BASE}/search/movie"))
+        .query(&[("api_key", api_key), ("query", title)]);
+    if let Some(year_value) = year {
+        let year_string = year_value.to_string();
+        request = request.query(&[("year", year_string.as_str())]);
+    }
+
+    let response = request.send().await.map_err(http_err)?;
+    let envelope: SearchEnvelope<TmdbMovieResult> =
+        parse_response(response, "search/movie").await?;
+
+    Ok(envelope
+        .results
+        .into_iter()
+        .map(|raw| MatchCandidate {
+            provider_id: raw.id.to_string(),
+            title: raw.title,
+            year: parse_year(raw.release_date.as_deref()),
+        })
+        .collect())
+}
+
+pub async fn search_show(
+    client: &Client,
+    api_key: &str,
+    title: &str,
+    year: Option<i32>,
+) -> AppResult<Vec<MatchCandidate>> {
+    let mut request = client
+        .get(format!("{API_BASE}/search/tv"))
+        .query(&[("api_key", api_key), ("query", title)]);
+    if let Some(year_value) = year {
+        let year_string = year_value.to_string();
+        request = request.query(&[("first_air_date_year", year_string.as_str())]);
+    }
+
+    let response = request.send().await.map_err(http_err)?;
+    let envelope: SearchEnvelope<TmdbShowResult> =
+        parse_response(response, "search/tv").await?;
+
+    Ok(envelope
+        .results
+        .into_iter()
+        .map(|raw| MatchCandidate {
+            provider_id: raw.id.to_string(),
+            title: raw.name,
+            year: parse_year(raw.first_air_date.as_deref()),
+        })
+        .collect())
+}
+
+pub async fn fetch_movie_details(
+    client: &Client,
+    api_key: &str,
+    tmdb_id: &str,
+) -> AppResult<TmdbMovieDetails> {
+    let response = client
+        .get(format!("{API_BASE}/movie/{tmdb_id}"))
+        .query(&[("api_key", api_key), ("append_to_response", "credits")])
+        .send()
+        .await
+        .map_err(http_err)?;
+
+    parse_response(response, "movie/details").await
+}
+
+pub async fn fetch_show_details(
+    client: &Client,
+    api_key: &str,
+    tmdb_id: &str,
+) -> AppResult<TmdbShowDetails> {
+    let response = client
+        .get(format!("{API_BASE}/tv/{tmdb_id}"))
+        .query(&[("api_key", api_key), ("append_to_response", "credits")])
+        .send()
+        .await
+        .map_err(http_err)?;
+
+    parse_response(response, "tv/details").await
+}
+
+/// Downloads `poster_path` (a relative TMDB path like `/abc.jpg`) into
+/// `dest`. Streams the response body to keep memory bounded.
+pub async fn download_poster(
+    client: &Client,
+    poster_path: &str,
+    dest: &Path,
+) -> AppResult<()> {
+    let url = format!("{IMAGE_BASE}{poster_path}");
+    let mut response = client.get(&url).send().await.map_err(http_err)?;
+
+    if !response.status().is_success() {
+        return Err(AppError::Other(format!(
+            "poster download failed: {} {}",
+            response.status(),
+            url
+        )));
+    }
+
+    if let Some(parent) = dest.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+
+    let mut file = tokio::fs::File::create(dest).await?;
+    while let Some(chunk) = response.chunk().await.map_err(http_err)? {
+        file.write_all(&chunk).await?;
+    }
+    file.flush().await?;
+
+    Ok(())
+}
+
+fn http_err(error: reqwest::Error) -> AppError {
+    AppError::Other(format!("tmdb http: {error}"))
+}
+
+async fn parse_response<T: for<'de> Deserialize<'de>>(
+    response: reqwest::Response,
+    endpoint: &str,
+) -> AppResult<T> {
+    let status = response.status();
+    if status == StatusCode::UNAUTHORIZED {
+        return Err(AppError::Other(format!(
+            "auth_required: {endpoint} returned 401"
+        )));
+    }
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        return Err(AppError::Other(format!(
+            "tmdb {endpoint} returned {status}: {body}"
+        )));
+    }
+
+    response
+        .json::<T>()
+        .await
+        .map_err(|error| AppError::Other(format!("tmdb {endpoint} parse: {error}")))
+}
+
+fn parse_year(date: Option<&str>) -> Option<i32> {
+    date.and_then(|d| d.get(0..4)).and_then(|year| year.parse().ok())
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -161,6 +161,8 @@ export const api = {
   setTmdbApiKey: (key: string) => invoke<void>('set_tmdb_api_key', { key }),
   metadataStatusCounts: () =>
     invoke<MetadataStatusCounts>('metadata_status_counts'),
+  fetchMetadataNow: (kind: 'show' | 'movie', id: number) =>
+    invoke<void>('fetch_metadata_now', { kind, id }),
 
   pickFolder: () =>
     open({

--- a/src/routes/films/[id]/edit/+page.svelte
+++ b/src/routes/films/[id]/edit/+page.svelte
@@ -17,6 +17,7 @@
   let loading = $state(true);
   let saving = $state(false);
   let busyPoster = $state(false);
+  let syncingMetadata = $state(false);
   let error = $state<string | null>(null);
 
   let titleDraft = $state('');
@@ -253,7 +254,28 @@
         </CardHeader>
       </Card>
 
-      <div class="flex justify-end gap-2">
+      <div class="flex flex-wrap justify-end gap-2">
+        <Button
+          variant="secondary"
+          disabled={!movie || syncingMetadata}
+          onclick={async () => {
+            if (!movie) {
+              return;
+            }
+            syncingMetadata = true;
+            error = null;
+            try {
+              await api.fetchMetadataNow('movie', movie.id);
+              await load(movie.id);
+            } catch (caught) {
+              error = String(caught);
+            } finally {
+              syncingMetadata = false;
+            }
+          }}
+        >
+          {syncingMetadata ? 'Syncing…' : 'Sync now (temp)'}
+        </Button>
         <Button
           variant="ghost"
           onclick={() => movie && goto(`/films/${movie.id}`)}

--- a/src/routes/series/[id]/edit/+page.svelte
+++ b/src/routes/series/[id]/edit/+page.svelte
@@ -20,6 +20,7 @@
   let busyPoster = $state(false);
   let deleting = $state(false);
   let confirmDeleteOpen = $state(false);
+  let syncingMetadata = $state(false);
   let error = $state<string | null>(null);
 
   let titleDraft = $state('');
@@ -314,7 +315,28 @@
         </CardContent>
       </Card>
 
-      <div class="flex justify-end gap-2">
+      <div class="flex flex-wrap justify-end gap-2">
+        <Button
+          variant="secondary"
+          disabled={!show || syncingMetadata}
+          onclick={async () => {
+            if (!show) {
+              return;
+            }
+            syncingMetadata = true;
+            error = null;
+            try {
+              await api.fetchMetadataNow('show', show.id);
+              await load(show.id);
+            } catch (caught) {
+              error = String(caught);
+            } finally {
+              syncingMetadata = false;
+            }
+          }}
+        >
+          {syncingMetadata ? 'Syncing…' : 'Sync now (temp)'}
+        </Button>
         <Button
           variant="ghost"
           onclick={() => show && goto(`/series/${show.id}`)}


### PR DESCRIPTION
## Summary
- ``src-tauri/src/metadata/tmdb.rs`` — concrete TMDB v3 client.
- ``src-tauri/src/metadata/matching.rs`` — pure ``pick_confident_match`` + 10 unit tests covering year tolerance, NFKD-fold, parenthetical / leading-article stripping, ambiguity → None.
- ``src-tauri/src/metadata/apply.rs`` — DB write helpers respecting manual posters and using ``COALESCE`` so TMDB nulls don't wipe scanner-derived fields.
- Shared ``reqwest::Client`` in app state. New ``fetch_metadata_now(kind, id)`` command runs the whole pipeline synchronously for one row.
- Temporary "Sync now (temp)" button on the series and films edit pages until the worker arrives in PR C.

## Why
PR B is the verification harness: paste a TMDB key, click the temporary button, watch a row enrich end-to-end. No worker, no queue. Lays the matcher + client + apply pieces the worker will use.

## Test plan
- [ ] ``cargo test metadata::matching`` — 10 passing.
- [ ] Paste a TMDB v3 API key at ``/settings/metadata``.
- [ ] Open any series, click "Sync now (temp)" — overview/year/genres/poster fill in.
- [ ] Same on a movie.
- [ ] Edit a title inline first → "Sync now" is a no-op (metadata_locked = 1).
- [ ] Upload a manual poster → "Sync now" updates text fields but leaves the poster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)