### PR TITLE
Metadata sync PR C: worker, scanner enqueue, Needs-review UI

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -43,7 +43,7 @@ pub async fn remove_library(db: State<'_, Db>, id: i64) -> AppResult<()> {
 }
 
 #[tauri::command]
-pub async fn scan_libraries(db: State<'_, Db>) -> AppResult<ScanReport> {
+pub async fn scan_libraries(app: AppHandle, db: State<'_, Db>) -> AppResult<ScanReport> {
     let libs = queries::list_libraries(&db).await?;
     let mut report = ScanReport::default();
     for lib in libs {
@@ -57,6 +57,7 @@ pub async fn scan_libraries(db: State<'_, Db>) -> AppResult<ScanReport> {
         report.episodes_added += r.episodes_added;
         report.shows_added += r.shows_added;
     }
+    wake_worker(&app);
     Ok(report)
 }
 
@@ -206,12 +207,26 @@ pub async fn get_tmdb_api_key(db: State<'_, Db>) -> AppResult<Option<String>> {
 }
 
 #[tauri::command]
-pub async fn set_tmdb_api_key(db: State<'_, Db>, key: String) -> AppResult<()> {
+pub async fn set_tmdb_api_key(
+    app: AppHandle,
+    db: State<'_, Db>,
+    key: String,
+) -> AppResult<()> {
     let trimmed = key.trim();
     if trimmed.is_empty() {
-        queries::delete_app_setting(&db, "tmdb_api_key").await
+        queries::delete_app_setting(&db, "tmdb_api_key").await?;
     } else {
-        queries::set_app_setting(&db, "tmdb_api_key", trimmed).await
+        queries::set_app_setting(&db, "tmdb_api_key", trimmed).await?;
+        crate::metadata::queries::wake_parked(&db).await?;
+    }
+
+    wake_worker(&app);
+    Ok(())
+}
+
+fn wake_worker(app: &AppHandle) {
+    if let Some(notify) = app.try_state::<std::sync::Arc<tokio::sync::Notify>>() {
+        notify.notify_one();
     }
 }
 
@@ -223,131 +238,115 @@ pub async fn metadata_status_counts(
 }
 
 #[tauri::command]
-pub async fn fetch_metadata_now(
+pub async fn refresh_metadata(
     app: AppHandle,
     db: State<'_, Db>,
-    http: State<'_, reqwest::Client>,
     kind: String,
     id: i64,
 ) -> AppResult<()> {
-    let api_key = queries::get_app_setting(&db, "tmdb_api_key")
-        .await?
-        .ok_or_else(|| AppError::Other("auth_required: no TMDB key configured".to_string()))?;
-
-    let app_data_dir = app
-        .path()
-        .app_data_dir()
-        .map_err(|error| AppError::Other(format!("app_data_dir: {error}")))?;
-    let posters_dir = app_data_dir.join("posters");
-
-    let outcome = match kind.as_str() {
-        "movie" => fetch_one_movie(&db, &http, &api_key, id).await?,
-        "show" => fetch_one_show(&db, &http, &api_key, id).await?,
-        other => {
-            return Err(AppError::Other(format!("unknown kind: {other}")));
-        }
+    let table = match kind.as_str() {
+        "show" => "shows",
+        "movie" => "movies",
+        other => return Err(AppError::Other(format!("unknown kind: {other}"))),
     };
 
-    if let Some((poster_url, dest_filename)) = outcome {
-        let dest = posters_dir.join(dest_filename);
-        crate::metadata::tmdb::download_poster(&http, &poster_url, &dest).await?;
-    }
+    sqlx::query(&format!("UPDATE {table} SET metadata_locked = 0 WHERE id = ?1"))
+        .bind(id)
+        .execute(&*db)
+        .await?;
+
+    crate::metadata::queries::force_enqueue(&db, &kind, id).await?;
+    wake_worker(&app);
 
     Ok(())
 }
 
-async fn fetch_one_movie(
-    db: &Db,
-    http: &reqwest::Client,
-    api_key: &str,
-    movie_id: i64,
-) -> AppResult<Option<(String, String)>> {
-    let mut tx = db.begin().await?;
-
-    let locked: i64 = sqlx::query_scalar("SELECT metadata_locked FROM movies WHERE id = ?1")
-        .bind(movie_id)
-        .fetch_one(&mut *tx)
-        .await?;
-    if locked != 0 {
-        tx.rollback().await?;
-        return Ok(None);
-    }
-
-    let (title, year): (String, Option<i32>) =
-        sqlx::query_as("SELECT title, year FROM movies WHERE id = ?1")
-            .bind(movie_id)
-            .fetch_one(&mut *tx)
-            .await?;
-    tx.rollback().await?;
-
-    let candidates = crate::metadata::tmdb::search_movie(http, api_key, &title, year).await?;
-    let Some(pick) =
-        crate::metadata::matching::pick_confident_match(&title, year, &candidates)
-    else {
-        return Ok(None);
+#[tauri::command]
+pub async fn unlink_metadata(
+    app: AppHandle,
+    db: State<'_, Db>,
+    kind: String,
+    id: i64,
+) -> AppResult<()> {
+    let (table, extras) = match kind.as_str() {
+        "show" => ("shows", "first_air_date = NULL, "),
+        "movie" => ("movies", "runtime_minutes = NULL, "),
+        other => return Err(AppError::Other(format!("unknown kind: {other}"))),
     };
 
-    let details =
-        crate::metadata::tmdb::fetch_movie_details(http, api_key, &pick.provider_id).await?;
+    let sql = format!(
+        "UPDATE {table} SET
+             provider = NULL,
+             provider_id = NULL,
+             rating = NULL,
+             genres = NULL,
+             top_cast = NULL,
+             {extras}
+             metadata_synced_at = NULL,
+             metadata_locked = 0
+         WHERE id = ?1"
+    );
 
-    let mut tx = db.begin().await?;
-    let download_ext =
-        crate::metadata::apply::apply_movie_details(&mut *tx, movie_id, &details).await?;
-    tx.commit().await?;
+    sqlx::query(&sql).bind(id).execute(&*db).await?;
+    crate::metadata::queries::force_enqueue(&db, &kind, id).await?;
+    wake_worker(&app);
 
-    Ok(match (download_ext, details.poster_path) {
-        (Some(extension), Some(poster_path)) => {
-            Some((poster_path, format!("movie-{movie_id}.{extension}")))
-        }
-        _ => None,
-    })
+    Ok(())
 }
 
-async fn fetch_one_show(
-    db: &Db,
-    http: &reqwest::Client,
-    api_key: &str,
-    show_id: i64,
-) -> AppResult<Option<(String, String)>> {
-    let mut tx = db.begin().await?;
+#[tauri::command]
+pub async fn metadata_search(
+    db: State<'_, Db>,
+    http: State<'_, reqwest::Client>,
+    kind: String,
+    query: String,
+    year: Option<i32>,
+) -> AppResult<Vec<crate::metadata::matching::MatchCandidate>> {
+    let api_key = queries::get_app_setting(&db, "tmdb_api_key")
+        .await?
+        .ok_or_else(|| AppError::Other("no TMDB key configured".to_string()))?;
 
-    let locked: i64 = sqlx::query_scalar("SELECT metadata_locked FROM shows WHERE id = ?1")
-        .bind(show_id)
-        .fetch_one(&mut *tx)
-        .await?;
-    if locked != 0 {
-        tx.rollback().await?;
-        return Ok(None);
+    match kind.as_str() {
+        "movie" => crate::metadata::tmdb::search_movie(&http, &api_key, &query, year).await,
+        "show" => crate::metadata::tmdb::search_show(&http, &api_key, &query, year).await,
+        other => Err(AppError::Other(format!("unknown kind: {other}"))),
     }
+}
 
-    let (title, year): (String, Option<i32>) =
-        sqlx::query_as("SELECT title, year FROM shows WHERE id = ?1")
-            .bind(show_id)
-            .fetch_one(&mut *tx)
-            .await?;
-    tx.rollback().await?;
-
-    let candidates = crate::metadata::tmdb::search_show(http, api_key, &title, year).await?;
-    let Some(pick) =
-        crate::metadata::matching::pick_confident_match(&title, year, &candidates)
-    else {
-        return Ok(None);
+#[tauri::command]
+pub async fn link_metadata(
+    app: AppHandle,
+    db: State<'_, Db>,
+    kind: String,
+    media_id: i64,
+    provider_id: String,
+) -> AppResult<()> {
+    let table = match kind.as_str() {
+        "show" => "shows",
+        "movie" => "movies",
+        other => return Err(AppError::Other(format!("unknown kind: {other}"))),
     };
 
-    let details =
-        crate::metadata::tmdb::fetch_show_details(http, api_key, &pick.provider_id).await?;
+    sqlx::query(&format!(
+        "UPDATE {table} SET provider = 'tmdb', provider_id = ?2, metadata_locked = 0
+         WHERE id = ?1"
+    ))
+    .bind(media_id)
+    .bind(&provider_id)
+    .execute(&*db)
+    .await?;
 
-    let mut tx = db.begin().await?;
-    let download_ext =
-        crate::metadata::apply::apply_show_details(&mut *tx, show_id, &details).await?;
-    tx.commit().await?;
+    crate::metadata::queries::force_enqueue(&db, &kind, media_id).await?;
+    wake_worker(&app);
 
-    Ok(match (download_ext, details.poster_path) {
-        (Some(extension), Some(poster_path)) => {
-            Some((poster_path, format!("show-{show_id}.{extension}")))
-        }
-        _ => None,
-    })
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn list_needs_review(
+    db: State<'_, Db>,
+) -> AppResult<Vec<crate::queries::NeedsReviewItem>> {
+    queries::list_needs_review(&db).await
 }
 
 /// Best-effort cleanup of a manual poster file. Only deletes the file when

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -29,7 +29,12 @@ pub fn run() {
                 .user_agent(concat!("rustflix/", env!("CARGO_PKG_VERSION")))
                 .build()
                 .expect("failed to build reqwest client");
-            app.manage(http_client);
+            app.manage(http_client.clone());
+
+            let pool_for_worker = app.state::<db::Db>().inner().clone();
+            let notify =
+                metadata::worker::spawn(pool_for_worker, http_client, app.handle().clone());
+            app.manage(notify);
 
             Ok(())
         })
@@ -61,7 +66,11 @@ pub fn run() {
             commands::get_tmdb_api_key,
             commands::set_tmdb_api_key,
             commands::metadata_status_counts,
-            commands::fetch_metadata_now,
+            commands::refresh_metadata,
+            commands::unlink_metadata,
+            commands::metadata_search,
+            commands::link_metadata,
+            commands::list_needs_review,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/metadata/mod.rs
+++ b/src-tauri/src/metadata/mod.rs
@@ -3,4 +3,6 @@
 
 pub mod apply;
 pub mod matching;
+pub mod queries;
 pub mod tmdb;
+pub mod worker;

--- a/src-tauri/src/metadata/queries.rs
+++ b/src-tauri/src/metadata/queries.rs
@@ -1,0 +1,268 @@
+//! Direct SQL helpers for `metadata_jobs`.
+
+use sqlx::SqlitePool;
+
+use crate::error::AppResult;
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct MetadataJob {
+    pub kind: String,
+    pub media_id: i64,
+    #[allow(dead_code)]
+    pub attempts: i64,
+    #[allow(dead_code)]
+    pub last_error: Option<String>,
+    pub next_attempt_at: i64,
+}
+
+pub async fn enqueue(pool: &SqlitePool, kind: &str, media_id: i64) -> AppResult<()> {
+    sqlx::query(
+        "INSERT INTO metadata_jobs (kind, media_id) VALUES (?1, ?2)
+         ON CONFLICT(kind, media_id) DO NOTHING",
+    )
+    .bind(kind)
+    .bind(media_id)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+/// Force-enqueue resets an existing job (or inserts a new one) so the
+/// worker treats it as fresh. Used by "Refresh metadata" and "Unlink".
+pub async fn force_enqueue(pool: &SqlitePool, kind: &str, media_id: i64) -> AppResult<()> {
+    sqlx::query(
+        "INSERT INTO metadata_jobs (kind, media_id) VALUES (?1, ?2)
+         ON CONFLICT(kind, media_id) DO UPDATE SET
+             attempts = 0,
+             next_attempt_at = strftime('%s','now'),
+             last_error = NULL",
+    )
+    .bind(kind)
+    .bind(media_id)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+/// Returns the next job whose next_attempt_at <= now and that isn't parked
+/// on 'auth_required'. None ⇒ queue is empty / fully parked.
+pub async fn next_due(pool: &SqlitePool) -> AppResult<Option<MetadataJob>> {
+    let job: Option<MetadataJob> = sqlx::query_as(
+        "SELECT kind, media_id, attempts, last_error, next_attempt_at
+         FROM metadata_jobs
+         WHERE COALESCE(last_error, '') <> 'auth_required'
+           AND attempts < 8
+           AND next_attempt_at <= strftime('%s','now')
+         ORDER BY next_attempt_at ASC
+         LIMIT 1",
+    )
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(job)
+}
+
+pub async fn park_auth(pool: &SqlitePool, kind: &str, media_id: i64) -> AppResult<()> {
+    sqlx::query(
+        "UPDATE metadata_jobs SET last_error = 'auth_required'
+         WHERE kind = ?1 AND media_id = ?2",
+    )
+    .bind(kind)
+    .bind(media_id)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+/// Clears the auth_required sentinel from every parked row so the worker
+/// can pick them up. Called when the user saves a new TMDB key.
+pub async fn wake_parked(pool: &SqlitePool) -> AppResult<()> {
+    sqlx::query(
+        "UPDATE metadata_jobs SET last_error = NULL,
+                                  next_attempt_at = strftime('%s','now')
+         WHERE last_error = 'auth_required'",
+    )
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+/// Exponential backoff: attempts++; next_attempt_at = now + min(60·2^attempts, 3600).
+pub async fn record_failure(
+    pool: &SqlitePool,
+    kind: &str,
+    media_id: i64,
+    message: &str,
+) -> AppResult<()> {
+    sqlx::query(
+        "UPDATE metadata_jobs SET
+             attempts = attempts + 1,
+             next_attempt_at = strftime('%s','now') +
+                 CASE WHEN (60 * (1 << MIN(attempts + 1, 6))) > 3600
+                      THEN 3600
+                      ELSE 60 * (1 << MIN(attempts + 1, 6))
+                 END,
+             last_error = ?3
+         WHERE kind = ?1 AND media_id = ?2",
+    )
+    .bind(kind)
+    .bind(media_id)
+    .bind(message)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+pub async fn delete_in_tx(
+    conn: &mut sqlx::SqliteConnection,
+    kind: &str,
+    media_id: i64,
+) -> AppResult<()> {
+    sqlx::query("DELETE FROM metadata_jobs WHERE kind = ?1 AND media_id = ?2")
+        .bind(kind)
+        .bind(media_id)
+        .execute(conn)
+        .await?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    async fn fresh_pool() -> SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("memory pool");
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .expect("migrations");
+        pool
+    }
+
+    async fn seed_show(pool: &SqlitePool) -> i64 {
+        sqlx::query("INSERT INTO libraries (id, path, kind) VALUES (1, '/tmp', 'series')")
+            .execute(pool)
+            .await
+            .expect("library");
+        sqlx::query(
+            "INSERT INTO shows (library_id, title, folder_path, fingerprint)
+             VALUES (1, 'Test', '/tmp/test', 'test')",
+        )
+        .execute(pool)
+        .await
+        .expect("show");
+        sqlx::query_scalar::<_, i64>("SELECT last_insert_rowid()")
+            .fetch_one(pool)
+            .await
+            .expect("show id")
+    }
+
+    #[tokio::test]
+    async fn enqueue_then_next_due_returns_the_job() {
+        let pool = fresh_pool().await;
+        let show_id = seed_show(&pool).await;
+
+        enqueue(&pool, "show", show_id).await.unwrap();
+
+        let job = next_due(&pool).await.unwrap().expect("a job");
+        assert_eq!(job.kind, "show");
+        assert_eq!(job.media_id, show_id);
+        assert_eq!(job.attempts, 0);
+    }
+
+    #[tokio::test]
+    async fn enqueue_twice_is_a_noop() {
+        let pool = fresh_pool().await;
+        let show_id = seed_show(&pool).await;
+
+        enqueue(&pool, "show", show_id).await.unwrap();
+        enqueue(&pool, "show", show_id).await.unwrap();
+
+        let count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM metadata_jobs WHERE kind = 'show' AND media_id = ?1",
+        )
+        .bind(show_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[tokio::test]
+    async fn park_auth_excludes_job_from_next_due() {
+        let pool = fresh_pool().await;
+        let show_id = seed_show(&pool).await;
+        enqueue(&pool, "show", show_id).await.unwrap();
+
+        park_auth(&pool, "show", show_id).await.unwrap();
+
+        let job = next_due(&pool).await.unwrap();
+        assert!(job.is_none(), "parked job should be excluded");
+    }
+
+    #[tokio::test]
+    async fn wake_parked_clears_sentinel() {
+        let pool = fresh_pool().await;
+        let show_id = seed_show(&pool).await;
+        enqueue(&pool, "show", show_id).await.unwrap();
+        park_auth(&pool, "show", show_id).await.unwrap();
+
+        wake_parked(&pool).await.unwrap();
+
+        let job = next_due(&pool).await.unwrap().expect("should be due again");
+        assert!(job.last_error.is_none());
+    }
+
+    #[tokio::test]
+    async fn record_failure_increments_attempts_and_backs_off() {
+        let pool = fresh_pool().await;
+        let show_id = seed_show(&pool).await;
+        enqueue(&pool, "show", show_id).await.unwrap();
+
+        record_failure(&pool, "show", show_id, "boom").await.unwrap();
+
+        let (attempts, next_attempt_at, last_error): (i64, i64, Option<String>) = sqlx::query_as(
+            "SELECT attempts, next_attempt_at, last_error FROM metadata_jobs
+             WHERE kind = 'show' AND media_id = ?1",
+        )
+        .bind(show_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(attempts, 1);
+        assert_eq!(last_error.as_deref(), Some("boom"));
+
+        let now: i64 = sqlx::query_scalar("SELECT CAST(strftime('%s','now') AS INTEGER)")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert!(next_attempt_at >= now + 60 && next_attempt_at <= now + 200);
+    }
+
+    #[tokio::test]
+    async fn force_enqueue_resets_existing_job() {
+        let pool = fresh_pool().await;
+        let show_id = seed_show(&pool).await;
+        enqueue(&pool, "show", show_id).await.unwrap();
+        record_failure(&pool, "show", show_id, "boom").await.unwrap();
+        record_failure(&pool, "show", show_id, "boom").await.unwrap();
+
+        force_enqueue(&pool, "show", show_id).await.unwrap();
+
+        let job = next_due(&pool).await.unwrap().expect("a job");
+        assert_eq!(job.attempts, 0);
+        assert!(job.last_error.is_none());
+    }
+}

--- a/src-tauri/src/metadata/worker.rs
+++ b/src-tauri/src/metadata/worker.rs
@@ -1,0 +1,234 @@
+//! Background worker that drains `metadata_jobs`. One task, sequential,
+//! 250ms pacing between requests. Waits on a Notify when the queue is
+//! empty, when there's no API key, or when every job is parked on
+//! auth_required.
+
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use sqlx::SqlitePool;
+use tauri::{AppHandle, Manager};
+use tokio::sync::Notify;
+use tokio::time::sleep;
+
+use crate::error::{AppError, AppResult};
+use crate::metadata::{apply, matching, queries, tmdb};
+use crate::queries as app_queries;
+
+const PACING_MS: u64 = 250;
+
+pub fn spawn(pool: SqlitePool, http: reqwest::Client, app: AppHandle) -> Arc<Notify> {
+    let notify = Arc::new(Notify::new());
+    let notify_clone = notify.clone();
+
+    tokio::spawn(async move {
+        if let Err(error) = run(pool, http, app, notify_clone).await {
+            eprintln!("metadata worker exited with error: {error}");
+        }
+    });
+
+    notify
+}
+
+async fn run(
+    pool: SqlitePool,
+    http: reqwest::Client,
+    app: AppHandle,
+    notify: Arc<Notify>,
+) -> AppResult<()> {
+    loop {
+        let api_key = app_queries::get_app_setting(&pool, "tmdb_api_key").await?;
+        let Some(api_key) = api_key else {
+            notify.notified().await;
+            continue;
+        };
+
+        let Some(job) = queries::next_due(&pool).await? else {
+            notify.notified().await;
+            continue;
+        };
+
+        let now = unix_now();
+        if job.next_attempt_at > now {
+            let wait = Duration::from_secs((job.next_attempt_at - now) as u64);
+            tokio::select! {
+                _ = sleep(wait) => {},
+                _ = notify.notified() => {},
+            }
+            continue;
+        }
+
+        match run_job(&pool, &http, &app, &api_key, &job).await {
+            Ok(()) => {}
+            Err(error) => handle_failure(&pool, &job, error).await?,
+        }
+
+        sleep(Duration::from_millis(PACING_MS)).await;
+    }
+}
+
+async fn run_job(
+    pool: &SqlitePool,
+    http: &reqwest::Client,
+    app: &AppHandle,
+    api_key: &str,
+    job: &queries::MetadataJob,
+) -> AppResult<()> {
+    let posters_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|error| AppError::Other(format!("app_data_dir: {error}")))?
+        .join("posters");
+
+    let outcome = match job.kind.as_str() {
+        "movie" => fetch_movie(pool, http, api_key, job.media_id).await?,
+        "show" => fetch_show(pool, http, api_key, job.media_id).await?,
+        other => {
+            return Err(AppError::Other(format!("unknown job kind: {other}")));
+        }
+    };
+
+    let mut tx = pool.begin().await?;
+    queries::delete_in_tx(&mut *tx, &job.kind, job.media_id).await?;
+    tx.commit().await?;
+
+    if let Some((poster_url, dest_filename)) = outcome {
+        let dest = posters_dir.join(dest_filename);
+        // Best-effort: a failed poster download doesn't invalidate the
+        // already-committed text metadata.
+        if let Err(error) = tmdb::download_poster(http, &poster_url, &dest).await {
+            eprintln!("poster download failed for {dest:?}: {error}");
+        }
+    }
+
+    Ok(())
+}
+
+async fn fetch_movie(
+    pool: &SqlitePool,
+    http: &reqwest::Client,
+    api_key: &str,
+    movie_id: i64,
+) -> AppResult<Option<(String, String)>> {
+    let row: Option<(i64, String, Option<i32>)> = sqlx::query_as(
+        "SELECT metadata_locked, title, year FROM movies WHERE id = ?1",
+    )
+    .bind(movie_id)
+    .fetch_optional(pool)
+    .await?;
+
+    let Some((locked, title, year)) = row else {
+        // Movie row was deleted before we got to it. Treat as success;
+        // the job row gets deleted by the caller.
+        return Ok(None);
+    };
+    if locked != 0 {
+        return Ok(None);
+    }
+
+    let candidates = tmdb::search_movie(http, api_key, &title, year).await?;
+    let Some(pick) = matching::pick_confident_match(&title, year, &candidates) else {
+        return Ok(None);
+    };
+
+    let details = tmdb::fetch_movie_details(http, api_key, &pick.provider_id).await?;
+
+    let mut tx = pool.begin().await?;
+
+    // Re-check metadata_locked inside the tx to handle the race where
+    // the user edited the row while we were over the wire.
+    let still_locked: i64 = sqlx::query_scalar(
+        "SELECT metadata_locked FROM movies WHERE id = ?1",
+    )
+    .bind(movie_id)
+    .fetch_one(&mut *tx)
+    .await?;
+    if still_locked != 0 {
+        tx.rollback().await?;
+        return Ok(None);
+    }
+
+    let download_ext = apply::apply_movie_details(&mut *tx, movie_id, &details).await?;
+    tx.commit().await?;
+
+    Ok(match (download_ext, details.poster_path) {
+        (Some(extension), Some(poster_path)) => {
+            Some((poster_path, format!("movie-{movie_id}.{extension}")))
+        }
+        _ => None,
+    })
+}
+
+async fn fetch_show(
+    pool: &SqlitePool,
+    http: &reqwest::Client,
+    api_key: &str,
+    show_id: i64,
+) -> AppResult<Option<(String, String)>> {
+    let row: Option<(i64, String, Option<i32>)> = sqlx::query_as(
+        "SELECT metadata_locked, title, year FROM shows WHERE id = ?1",
+    )
+    .bind(show_id)
+    .fetch_optional(pool)
+    .await?;
+
+    let Some((locked, title, year)) = row else {
+        return Ok(None);
+    };
+    if locked != 0 {
+        return Ok(None);
+    }
+
+    let candidates = tmdb::search_show(http, api_key, &title, year).await?;
+    let Some(pick) = matching::pick_confident_match(&title, year, &candidates) else {
+        return Ok(None);
+    };
+
+    let details = tmdb::fetch_show_details(http, api_key, &pick.provider_id).await?;
+
+    let mut tx = pool.begin().await?;
+
+    let still_locked: i64 = sqlx::query_scalar(
+        "SELECT metadata_locked FROM shows WHERE id = ?1",
+    )
+    .bind(show_id)
+    .fetch_one(&mut *tx)
+    .await?;
+    if still_locked != 0 {
+        tx.rollback().await?;
+        return Ok(None);
+    }
+
+    let download_ext = apply::apply_show_details(&mut *tx, show_id, &details).await?;
+    tx.commit().await?;
+
+    Ok(match (download_ext, details.poster_path) {
+        (Some(extension), Some(poster_path)) => {
+            Some((poster_path, format!("show-{show_id}.{extension}")))
+        }
+        _ => None,
+    })
+}
+
+async fn handle_failure(
+    pool: &SqlitePool,
+    job: &queries::MetadataJob,
+    error: AppError,
+) -> AppResult<()> {
+    let message = error.to_string();
+
+    if message.starts_with("auth_required") {
+        queries::park_auth(pool, &job.kind, job.media_id).await?;
+    } else {
+        queries::record_failure(pool, &job.kind, job.media_id, &message).await?;
+    }
+
+    Ok(())
+}
+
+fn unix_now() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}

--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -446,6 +446,33 @@ pub async fn continue_watching(pool: &SqlitePool, limit: i64) -> AppResult<Vec<C
     Ok(out)
 }
 
+#[derive(Debug, sqlx::FromRow, serde::Serialize, serde::Deserialize)]
+pub struct NeedsReviewItem {
+    pub kind: String,
+    pub id: i64,
+    pub title: String,
+    pub year: Option<i32>,
+}
+
+pub async fn list_needs_review(pool: &SqlitePool) -> AppResult<Vec<NeedsReviewItem>> {
+    let items: Vec<NeedsReviewItem> = sqlx::query_as(
+        "SELECT 'show' AS kind, id, title, year FROM shows
+            WHERE provider IS NULL
+              AND NOT EXISTS (SELECT 1 FROM metadata_jobs j
+                              WHERE j.kind = 'show' AND j.media_id = shows.id)
+         UNION ALL
+         SELECT 'movie' AS kind, id, title, year FROM movies
+            WHERE provider IS NULL
+              AND NOT EXISTS (SELECT 1 FROM metadata_jobs j
+                              WHERE j.kind = 'movie' AND j.media_id = movies.id)
+         ORDER BY title COLLATE NOCASE",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    Ok(items)
+}
+
 pub async fn get_app_setting(pool: &SqlitePool, key: &str) -> AppResult<Option<String>> {
     let value: Option<String> =
         sqlx::query_scalar("SELECT value FROM app_settings WHERE key = ?1")

--- a/src-tauri/src/scanner.rs
+++ b/src-tauri/src/scanner.rs
@@ -397,6 +397,7 @@ pub async fn scan_library(
                         .await?;
 
                         report.movies_added += 1;
+                        crate::metadata::queries::enqueue(pool, "movie", new_id).await?;
                         new_id
                     }
                 };
@@ -520,6 +521,7 @@ pub async fn scan_library(
                     report.episodes_added += 1;
                     if created_new_show {
                         report.shows_added += 1;
+                        crate::metadata::queries::enqueue(pool, "show", show_id).await?;
                     }
                 }
             }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -64,6 +64,19 @@ export interface MetadataStatusCounts {
   needs_review: number;
 }
 
+export interface MatchCandidate {
+  provider_id: string;
+  title: string;
+  year: number | null;
+}
+
+export interface NeedsReviewItem {
+  kind: 'show' | 'movie';
+  id: number;
+  title: string;
+  year: number | null;
+}
+
 export interface Episode {
   id: number;
   show_id: number;
@@ -161,8 +174,15 @@ export const api = {
   setTmdbApiKey: (key: string) => invoke<void>('set_tmdb_api_key', { key }),
   metadataStatusCounts: () =>
     invoke<MetadataStatusCounts>('metadata_status_counts'),
-  fetchMetadataNow: (kind: 'show' | 'movie', id: number) =>
-    invoke<void>('fetch_metadata_now', { kind, id }),
+  refreshMetadata: (kind: 'show' | 'movie', id: number) =>
+    invoke<void>('refresh_metadata', { kind, id }),
+  unlinkMetadata: (kind: 'show' | 'movie', id: number) =>
+    invoke<void>('unlink_metadata', { kind, id }),
+  metadataSearch: (kind: 'show' | 'movie', query: string, year: number | null) =>
+    invoke<MatchCandidate[]>('metadata_search', { kind, query, year }),
+  linkMetadata: (kind: 'show' | 'movie', mediaId: number, providerId: string) =>
+    invoke<void>('link_metadata', { kind, mediaId, providerId }),
+  listNeedsReview: () => invoke<NeedsReviewItem[]>('list_needs_review'),
 
   pickFolder: () =>
     open({

--- a/src/lib/components/MetadataMatchSheet.svelte
+++ b/src/lib/components/MetadataMatchSheet.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+  import {
+    api,
+    type MatchCandidate,
+    type NeedsReviewItem,
+  } from '$lib/api';
+  import { Button } from '$lib/components/ui/button';
+  import * as Sheet from '$lib/components/ui/sheet';
+
+  type Props = {
+    open: boolean;
+    item: NeedsReviewItem | null;
+    onClose: () => void;
+    onLinked: () => void;
+  };
+
+  let { open = $bindable(), item, onClose, onLinked }: Props = $props();
+
+  let candidates = $state<MatchCandidate[]>([]);
+  let searching = $state(false);
+  let error = $state<string | null>(null);
+
+  $effect(() => {
+    if (open && item) {
+      void runSearch();
+    }
+  });
+
+  async function runSearch() {
+    if (!item) {
+      return;
+    }
+    searching = true;
+    error = null;
+    candidates = [];
+    try {
+      candidates = await api.metadataSearch(item.kind, item.title, item.year);
+    } catch (caught) {
+      error = String(caught);
+    } finally {
+      searching = false;
+    }
+  }
+
+  async function pick(candidate: MatchCandidate) {
+    if (!item) {
+      return;
+    }
+    error = null;
+    try {
+      await api.linkMetadata(item.kind, item.id, candidate.provider_id);
+      onLinked();
+      onClose();
+    } catch (caught) {
+      error = String(caught);
+    }
+  }
+</script>
+
+<Sheet.Root bind:open>
+  <Sheet.Content side="right" class="w-full sm:max-w-md">
+    <Sheet.Header>
+      <Sheet.Title>Find a match</Sheet.Title>
+      <Sheet.Description>
+        {item ? `${item.title}${item.year ? ` (${item.year})` : ''}` : ''}
+      </Sheet.Description>
+    </Sheet.Header>
+
+    {#if error}
+      <p class="mt-3 text-sm text-destructive-foreground">{error}</p>
+    {/if}
+
+    {#if searching}
+      <p class="mt-3 text-sm text-muted-foreground">Searching…</p>
+    {:else}
+      <ul class="mt-4 flex flex-col gap-2">
+        {#each candidates as candidate (candidate.provider_id)}
+          <li>
+            <button
+              type="button"
+              onclick={() => pick(candidate)}
+              class="w-full rounded-md border border-border bg-background px-3 py-2 text-left text-sm transition-colors hover:bg-accent"
+            >
+              <div class="font-medium">{candidate.title}</div>
+              {#if candidate.year}
+                <div class="text-xs text-muted-foreground">{candidate.year}</div>
+              {/if}
+            </button>
+          </li>
+        {/each}
+        {#if candidates.length === 0}
+          <li class="text-sm text-muted-foreground">No candidates found.</li>
+        {/if}
+      </ul>
+    {/if}
+
+    <Sheet.Footer class="mt-6">
+      <Button variant="ghost" onclick={onClose}>Close</Button>
+    </Sheet.Footer>
+  </Sheet.Content>
+</Sheet.Root>

--- a/src/routes/films/[id]/edit/+page.svelte
+++ b/src/routes/films/[id]/edit/+page.svelte
@@ -265,7 +265,7 @@
             syncingMetadata = true;
             error = null;
             try {
-              await api.fetchMetadataNow('movie', movie.id);
+              await api.refreshMetadata('movie', movie.id);
               await load(movie.id);
             } catch (caught) {
               error = String(caught);
@@ -274,8 +274,31 @@
             }
           }}
         >
-          {syncingMetadata ? 'Syncing…' : 'Sync now (temp)'}
+          {syncingMetadata ? 'Refreshing…' : 'Refresh metadata'}
         </Button>
+        {#if movie?.provider}
+          <Button
+            variant="ghost"
+            disabled={!movie || syncingMetadata}
+            onclick={async () => {
+              if (!movie) {
+                return;
+              }
+              syncingMetadata = true;
+              error = null;
+              try {
+                await api.unlinkMetadata('movie', movie.id);
+                await load(movie.id);
+              } catch (caught) {
+                error = String(caught);
+              } finally {
+                syncingMetadata = false;
+              }
+            }}
+          >
+            Unlink
+          </Button>
+        {/if}
         <Button
           variant="ghost"
           onclick={() => movie && goto(`/films/${movie.id}`)}

--- a/src/routes/library/needs-review/+page.svelte
+++ b/src/routes/library/needs-review/+page.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+  import { api, type NeedsReviewItem } from '$lib/api';
+  import MetadataMatchSheet from '$lib/components/MetadataMatchSheet.svelte';
+  import { Button } from '$lib/components/ui/button';
+
+  let items = $state<NeedsReviewItem[]>([]);
+  let loading = $state(true);
+  let error = $state<string | null>(null);
+  let active = $state<NeedsReviewItem | null>(null);
+  let sheetOpen = $state(false);
+
+  $effect(() => {
+    void load();
+  });
+
+  async function load() {
+    loading = true;
+    try {
+      items = await api.listNeedsReview();
+    } catch (caught) {
+      error = String(caught);
+    } finally {
+      loading = false;
+    }
+  }
+
+  function openSheet(item: NeedsReviewItem) {
+    active = item;
+    sheetOpen = true;
+  }
+</script>
+
+<div class="mx-auto max-w-3xl px-6 py-8">
+  <h1 class="mb-6 text-3xl font-bold tracking-tight">Needs review</h1>
+  <p class="mb-6 text-sm text-muted-foreground">
+    These items couldn't be auto-linked to a TMDB record. Pick the right match.
+  </p>
+
+  {#if error}
+    <p class="mb-4 text-sm text-destructive-foreground">{error}</p>
+  {/if}
+
+  {#if loading}
+    <p class="text-sm text-muted-foreground">Loading…</p>
+  {:else if items.length === 0}
+    <p class="text-sm text-muted-foreground">Everything is matched. Nothing to review.</p>
+  {:else}
+    <ul class="flex flex-col gap-2">
+      {#each items as item (item.kind + ':' + item.id)}
+        <li
+          class="flex items-center justify-between rounded-md border border-border bg-card px-4 py-3"
+        >
+          <div>
+            <div class="font-medium">{item.title}</div>
+            <div class="text-xs uppercase tracking-wide text-muted-foreground">
+              {item.kind}{item.year ? ` · ${item.year}` : ''}
+            </div>
+          </div>
+          <Button onclick={() => openSheet(item)}>Match…</Button>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</div>
+
+<MetadataMatchSheet
+  bind:open={sheetOpen}
+  item={active}
+  onClose={() => (sheetOpen = false)}
+  onLinked={() => load()}
+/>

--- a/src/routes/series/[id]/edit/+page.svelte
+++ b/src/routes/series/[id]/edit/+page.svelte
@@ -326,7 +326,7 @@
             syncingMetadata = true;
             error = null;
             try {
-              await api.fetchMetadataNow('show', show.id);
+              await api.refreshMetadata('show', show.id);
               await load(show.id);
             } catch (caught) {
               error = String(caught);
@@ -335,8 +335,31 @@
             }
           }}
         >
-          {syncingMetadata ? 'Syncing…' : 'Sync now (temp)'}
+          {syncingMetadata ? 'Refreshing…' : 'Refresh metadata'}
         </Button>
+        {#if show?.provider}
+          <Button
+            variant="ghost"
+            disabled={!show || syncingMetadata}
+            onclick={async () => {
+              if (!show) {
+                return;
+              }
+              syncingMetadata = true;
+              error = null;
+              try {
+                await api.unlinkMetadata('show', show.id);
+                await load(show.id);
+              } catch (caught) {
+                error = String(caught);
+              } finally {
+                syncingMetadata = false;
+              }
+            }}
+          >
+            Unlink
+          </Button>
+        {/if}
         <Button
           variant="ghost"
           onclick={() => show && goto(`/series/${show.id}`)}


### PR DESCRIPTION
## Summary
- Background async worker drains ``metadata_jobs`` at 250ms cadence with exponential backoff. Parks on 401 instead of burning retries.
- Scanner enqueues new shows / movies; ``scan_libraries`` wakes the worker afterwards.
- ``refresh_metadata`` / ``unlink_metadata`` / ``metadata_search`` / ``link_metadata`` / ``list_needs_review`` commands replace the temporary ``fetch_metadata_now``.
- Edit pages get **Refresh metadata** + **Unlink** buttons.
- New ``/library/needs-review`` list view with a TMDB-search match sheet.
- Six new in-memory unit tests on the queue SQL helpers (enqueue / park / wake / backoff / force-enqueue).

Closes out the metadata sync spec at ``docs/superpowers/specs/2026-05-24-metadata-sync-design.md``.

## Test plan
- [ ] ``cargo test metadata`` — 16 passing (10 matcher + 6 queue).
- [ ] Paste TMDB key in ``/settings/metadata`` → existing pending jobs drain → posters / overviews / genres / ratings populate.
- [ ] Add a new library → scanner enqueues → worker processes → metadata appears without user action.
- [ ] Clear the key → in-flight 401 parks the job (no retry storm). Re-paste → parked jobs resume.
- [ ] Edit a title inline → next worker pass skips that row (``metadata_locked = 1``).
- [ ] Click **Unlink** → row clears, re-enqueued, lock reset, worker fills it in.
- [ ] Add a known-ambiguous series ("The Office") → appears at ``/library/needs-review`` → pick a candidate → row links.
- [ ] Kill the app mid-fetch → restart → job completes on the next worker pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)