### PR TITLE
Admin PR 2: MVP UI — table picker and shows grid

### DIFF
--- a/src/lib/admin/AdminCell.svelte
+++ b/src/lib/admin/AdminCell.svelte
@@ -1,0 +1,132 @@
+<script lang="ts">
+  import type { ColumnConfig } from './tables';
+  import { Pencil } from '$lib/lucide';
+
+  type Props = {
+    column: ColumnConfig;
+    value: unknown;
+    onSave: (next: unknown) => Promise<void> | void;
+  };
+
+  let { column, value, onSave }: Props = $props();
+
+  let editing = $state(false);
+  let draft = $state('');
+  let saving = $state(false);
+
+  function display(raw: unknown): string {
+    if (raw === null || raw === undefined) {
+      return '';
+    }
+    if (column.kind === 'datetime' && typeof raw === 'number') {
+      return new Date(raw * 1000).toISOString().replace('T', ' ').slice(0, 19);
+    }
+    if (column.kind === 'boolean') {
+      return raw ? '✓' : '';
+    }
+    if (column.kind === 'json' && typeof raw === 'string') {
+      try {
+        const parsed = JSON.parse(raw);
+        if (Array.isArray(parsed) && parsed.length > 0 && typeof parsed[0] === 'string') {
+          return parsed.join(', ');
+        }
+        return `${parsed.length ?? 0} items`;
+      } catch {
+        return raw;
+      }
+    }
+    return String(raw);
+  }
+
+  function startEdit() {
+    if (column.readonly || editing) {
+      return;
+    }
+    if (column.kind === 'boolean') {
+      void onSave(value ? 0 : 1);
+      return;
+    }
+    draft = value === null || value === undefined ? '' : String(value);
+    editing = true;
+  }
+
+  function cancelEdit() {
+    editing = false;
+    draft = '';
+  }
+
+  async function commitEdit() {
+    const next = draft.trim();
+    if (next === String(value ?? '')) {
+      cancelEdit();
+      return;
+    }
+
+    const payload = parseDraft(next);
+    saving = true;
+    try {
+      await onSave(payload);
+    } finally {
+      saving = false;
+      editing = false;
+      draft = '';
+    }
+  }
+
+  function parseDraft(input: string): unknown {
+    if (input.length === 0) {
+      return null;
+    }
+    if (column.kind === 'json') {
+      return input;
+    }
+    // Heuristic: if the field name implies a number and the input parses
+    // cleanly, send a number. Otherwise send a string.
+    const asNumber = Number(input);
+    if (
+      !Number.isNaN(asNumber) &&
+      Number.isFinite(asNumber) &&
+      /^-?\d+(\.\d+)?$/.test(input)
+    ) {
+      return asNumber;
+    }
+    return input;
+  }
+
+  function autoFocus(node: HTMLInputElement) {
+    node.focus();
+    node.select();
+  }
+</script>
+
+{#if editing}
+  <input
+    use:autoFocus
+    bind:value={draft}
+    disabled={saving}
+    onblur={commitEdit}
+    onkeydown={(event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        void commitEdit();
+      } else if (event.key === 'Escape') {
+        event.preventDefault();
+        cancelEdit();
+      }
+    }}
+    class="w-full rounded border border-primary/60 bg-background/60 px-2 py-1 text-sm text-foreground outline-none"
+  />
+{:else if column.readonly}
+  <span class="text-sm text-muted-foreground">{display(value)}</span>
+{:else}
+  <button
+    type="button"
+    onclick={startEdit}
+    class="group/cell -mx-1 flex w-full min-w-0 items-center gap-2 rounded px-1 py-0.5 text-left text-sm transition hover:bg-background/30"
+  >
+    <span class="truncate">{display(value) || '—'}</span>
+    <Pencil
+      class="size-3 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover/cell:opacity-100"
+    />
+  </button>
+{/if}

--- a/src/lib/admin/DataGrid.svelte
+++ b/src/lib/admin/DataGrid.svelte
@@ -1,0 +1,111 @@
+<script lang="ts">
+  import { api } from '$lib/api';
+  import { RefreshCw } from '$lib/lucide';
+  import AdminCell from './AdminCell.svelte';
+  import { columnLabel, type TableConfig } from './tables';
+
+  type Props = {
+    config: TableConfig;
+  };
+
+  let { config }: Props = $props();
+
+  let rows = $state<Record<string, unknown>[]>([]);
+  let loading = $state(true);
+  let error = $state<string | null>(null);
+
+  const visibleColumns = $derived(config.columns.filter((column) => !column.hideInGrid));
+
+  $effect(() => {
+    void load();
+  });
+
+  async function load() {
+    loading = true;
+    error = null;
+    try {
+      rows = await api.adminListRows(
+        config.id,
+        config.defaultSort.column,
+        config.defaultSort.direction,
+      );
+    } catch (caught) {
+      error = String(caught);
+    } finally {
+      loading = false;
+    }
+  }
+
+  function pkValuesFor(row: Record<string, unknown>): unknown[] {
+    return config.primaryKey.map((column) => row[column]);
+  }
+
+  async function saveCell(
+    row: Record<string, unknown>,
+    columnKey: string,
+    next: unknown,
+  ) {
+    const previous = row[columnKey];
+    row[columnKey] = next;
+    try {
+      await api.adminUpdateRow(config.id, pkValuesFor(row), {
+        [columnKey]: next,
+      });
+    } catch (caught) {
+      row[columnKey] = previous;
+      error = String(caught);
+    }
+  }
+</script>
+
+<div class="flex items-center justify-between gap-3 px-6 pt-6 pb-3">
+  <h1 class="text-2xl font-bold tracking-tight">{config.label}</h1>
+  <button
+    type="button"
+    onclick={load}
+    disabled={loading}
+    class="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-50"
+    aria-label="Refresh"
+  >
+    <RefreshCw class="size-4 {loading ? 'animate-spin' : ''}" />
+  </button>
+</div>
+
+{#if error}
+  <div class="mx-6 mb-4 rounded-md border border-destructive/30 bg-destructive/10 px-4 py-2 text-sm text-destructive-foreground">
+    {error}
+  </div>
+{/if}
+
+<div class="overflow-x-auto px-6 pb-8">
+  {#if loading}
+    <p class="text-sm text-muted-foreground">Loading…</p>
+  {:else if rows.length === 0}
+    <p class="text-sm text-muted-foreground">No rows.</p>
+  {:else}
+    <table class="w-full border-collapse text-sm">
+      <thead>
+        <tr class="border-b border-border text-xs uppercase tracking-wide text-muted-foreground">
+          {#each visibleColumns as column (column.key)}
+            <th class="px-2 py-2 text-left font-medium">{columnLabel(column)}</th>
+          {/each}
+        </tr>
+      </thead>
+      <tbody>
+        {#each rows as row (config.primaryKey.map((k) => row[k]).join(':'))}
+          <tr class="border-b border-border/50 hover:bg-accent/20">
+            {#each visibleColumns as column (column.key)}
+              <td class="px-2 py-1.5 align-middle">
+                <AdminCell
+                  {column}
+                  value={row[column.key]}
+                  onSave={(next) => saveCell(row, column.key, next)}
+                />
+              </td>
+            {/each}
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  {/if}
+</div>

--- a/src/lib/admin/tables.ts
+++ b/src/lib/admin/tables.ts
@@ -1,0 +1,67 @@
+export type TableId =
+  | 'libraries'
+  | 'shows'
+  | 'movies'
+  | 'episodes'
+  | 'watch_history'
+  | 'metadata_jobs'
+  | 'app_settings';
+
+export interface ColumnConfig {
+  key: string;
+  label?: string;
+  readonly?: boolean;
+  hideInGrid?: boolean;
+  kind?: 'text' | 'json' | 'datetime' | 'boolean';
+  fkTable?: TableId;
+  fkLabel?: string;
+}
+
+export interface TableConfig {
+  id: TableId;
+  label: string;
+  primaryKey: string[];
+  defaultSort: { column: string; direction: 'asc' | 'desc' };
+  columns: ColumnConfig[];
+}
+
+// Only `shows` is configured for now — the other six configs land in the
+// admin PR 3 alongside the drawer + FK chips. Adding a new table here
+// before then will work but it'll render with default behaviour only.
+export const TABLES: Partial<Record<TableId, TableConfig>> = {
+  shows: {
+    id: 'shows',
+    label: 'Shows',
+    primaryKey: ['id'],
+    defaultSort: { column: 'title', direction: 'asc' },
+    columns: [
+      { key: 'id', readonly: true },
+      { key: 'title' },
+      { key: 'year' },
+      { key: 'library_id', fkTable: 'libraries', fkLabel: 'path' },
+      { key: 'provider' },
+      { key: 'rating', readonly: true },
+      { key: 'metadata_locked', kind: 'boolean' },
+      { key: 'genres', kind: 'json', hideInGrid: true },
+      { key: 'top_cast', kind: 'json', hideInGrid: true },
+      { key: 'overview', kind: 'text', hideInGrid: true },
+      { key: 'folder_path' },
+      { key: 'fingerprint', readonly: true },
+      { key: 'added_at', kind: 'datetime', readonly: true },
+    ],
+  },
+};
+
+export function humanizeKey(key: string): string {
+  return key
+    .split('_')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+export function columnLabel(column: ColumnConfig): string {
+  if (column.label) {
+    return column.label;
+  }
+  return humanizeKey(column.key);
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -184,6 +184,31 @@ export const api = {
     invoke<void>('link_metadata', { kind, mediaId, providerId }),
   listNeedsReview: () => invoke<NeedsReviewItem[]>('list_needs_review'),
 
+  adminListRows: (table: string, sortColumn?: string, direction?: 'asc' | 'desc') =>
+    invoke<Record<string, unknown>[]>('admin_list_rows', {
+      table,
+      sortColumn: sortColumn ?? null,
+      direction: direction ?? null,
+    }),
+  adminUpdateRow: (
+    table: string,
+    primaryKeyValues: unknown[],
+    patch: Record<string, unknown>,
+  ) =>
+    invoke<void>('admin_update_row', {
+      table,
+      primaryKeyValues,
+      patch,
+    }),
+  adminDeleteRows: (table: string, primaryKeys: unknown[][]) =>
+    invoke<void>('admin_delete_rows', { table, primaryKeys }),
+  adminFkLabel: (table: string, labelColumn: string, pkValue: unknown) =>
+    invoke<string | null>('admin_fk_label', {
+      table,
+      labelColumn,
+      pkValue,
+    }),
+
   pickFolder: () =>
     open({
       directory: true,

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import { ChevronRight } from '$lib/lucide';
+  import { TABLES, type TableConfig } from '$lib/admin/tables';
+
+  const entries = Object.values(TABLES).filter(
+    (config): config is TableConfig => config !== undefined,
+  );
+</script>
+
+<div class="mx-auto max-w-3xl px-6 py-8">
+  <h1 class="mb-2 text-3xl font-bold tracking-tight">Admin</h1>
+  <p class="mb-6 text-sm text-muted-foreground">
+    Direct access to every persistent table. Use with care.
+  </p>
+
+  {#if entries.length === 0}
+    <p class="text-sm text-muted-foreground">No tables configured yet.</p>
+  {:else}
+    <ul class="flex flex-col gap-2">
+      {#each entries as config (config.id)}
+        <li>
+          <a
+            href={`/admin/${config.id}`}
+            class="flex items-center justify-between rounded-md border border-border bg-card px-4 py-3 transition-colors hover:bg-accent"
+          >
+            <div>
+              <div class="font-medium">{config.label}</div>
+              <div class="text-sm text-muted-foreground">{config.id}</div>
+            </div>
+            <ChevronRight class="size-4 text-muted-foreground" />
+          </a>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</div>

--- a/src/routes/admin/[table]/+page.svelte
+++ b/src/routes/admin/[table]/+page.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import { page } from '$app/stores';
+  import DataGrid from '$lib/admin/DataGrid.svelte';
+  import { TABLES, type TableId } from '$lib/admin/tables';
+  import { ChevronLeft } from '$lib/lucide';
+
+  const tableId = $derived($page.params.table as TableId);
+  const config = $derived(TABLES[tableId]);
+</script>
+
+{#if config}
+  <div>
+    <div class="px-6 pt-4">
+      <a
+        href="/admin"
+        class="inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <ChevronLeft class="size-4" />
+        All tables
+      </a>
+    </div>
+    <DataGrid {config} />
+  </div>
+{:else}
+  <div class="mx-auto max-w-3xl px-6 py-8">
+    <h1 class="mb-2 text-3xl font-bold tracking-tight">Table not configured</h1>
+    <p class="text-sm text-muted-foreground">
+      "<code>{tableId}</code>" doesn't have an admin config yet.
+    </p>
+    <a class="mt-4 inline-block text-sm underline" href="/admin">Back to tables</a>
+  </div>
+{/if}

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -33,5 +33,19 @@
         <ChevronRight class="size-4 text-muted-foreground" />
       </a>
     </li>
+    <li>
+      <a
+        href="/admin"
+        class="flex items-center justify-between rounded-md border border-border bg-card px-4 py-3 transition-colors hover:bg-accent"
+      >
+        <div>
+          <div class="font-medium">Admin / Database</div>
+          <div class="text-sm text-muted-foreground">
+            Direct access to every persistent table. For maintenance.
+          </div>
+        </div>
+        <ChevronRight class="size-4 text-muted-foreground" />
+      </a>
+    </li>
   </ul>
 </div>


### PR DESCRIPTION
## Summary
- New ``/admin`` table picker and ``/admin/[table]`` grid.
- Per-table TypeScript config (``src/lib/admin/tables.ts``); only ``shows`` configured for now.
- Generic ``DataGrid`` + ``AdminCell`` components with inline cell editing (text / boolean / json / datetime).
- Settings index gets an ``Admin / Database`` card.

## Test plan
- [ ] Navigate to ``/settings`` → click ``Admin / Database`` → ``Shows`` row → grid renders all your shows.
- [ ] Click a title cell → input takes focus → type → Enter → row updates; ``SELECT title FROM shows`` reflects the change.
- [ ] Click the metadata_locked column → toggles 0↔1.
- [ ] Click year → input → save.
- [ ] Refresh button reloads the grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)