### PR TITLE
Admin PR 3: row drawer, FK chips, all seven tables

### DIFF
--- a/src/lib/admin/AdminCell.svelte
+++ b/src/lib/admin/AdminCell.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { ColumnConfig } from './tables';
+  import FkChip from './FkChip.svelte';
   import { Pencil } from '$lib/lucide';
 
   type Props = {
@@ -99,7 +100,9 @@
   }
 </script>
 
-{#if editing}
+{#if column.fkTable && column.fkLabel && !editing}
+  <FkChip table={column.fkTable} labelColumn={column.fkLabel} {value} />
+{:else if editing}
   <input
     use:autoFocus
     bind:value={draft}

--- a/src/lib/admin/DataGrid.svelte
+++ b/src/lib/admin/DataGrid.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
+  import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
   import { api } from '$lib/api';
   import { RefreshCw } from '$lib/lucide';
   import AdminCell from './AdminCell.svelte';
+  import RowDrawer from './RowDrawer.svelte';
   import { columnLabel, type TableConfig } from './tables';
 
   type Props = {
@@ -14,7 +17,21 @@
   let loading = $state(true);
   let error = $state<string | null>(null);
 
-  const visibleColumns = $derived(config.columns.filter((column) => !column.hideInGrid));
+  const visibleColumns = $derived(
+    config.columns.filter((column) => !column.hideInGrid),
+  );
+
+  const rowParam = $derived($page.url.searchParams.get('row'));
+  const activeRow = $derived(rowParam ? findRowByPk(rows, rowParam) : null);
+  let drawerOpen = $state(false);
+
+  $effect(() => {
+    if (rowParam && activeRow) {
+      drawerOpen = true;
+    } else if (!rowParam) {
+      drawerOpen = false;
+    }
+  });
 
   $effect(() => {
     void load();
@@ -40,6 +57,22 @@
     return config.primaryKey.map((column) => row[column]);
   }
 
+  function pkStringFor(row: Record<string, unknown>): string {
+    return pkValuesFor(row).map((v) => String(v)).join(':');
+  }
+
+  function findRowByPk(
+    candidates: Record<string, unknown>[],
+    pkString: string,
+  ): Record<string, unknown> | null {
+    for (const row of candidates) {
+      if (pkStringFor(row) === pkString) {
+        return row;
+      }
+    }
+    return null;
+  }
+
   async function saveCell(
     row: Record<string, unknown>,
     columnKey: string,
@@ -53,6 +86,45 @@
       });
     } catch (caught) {
       row[columnKey] = previous;
+      error = String(caught);
+    }
+  }
+
+  function openDrawer(row: Record<string, unknown>) {
+    const url = new URL($page.url);
+    url.searchParams.set('row', pkStringFor(row));
+    void goto(url.pathname + url.search, { replaceState: false, keepFocus: true });
+  }
+
+  function closeDrawer() {
+    const url = new URL($page.url);
+    url.searchParams.delete('row');
+    void goto(url.pathname + (url.search ? url.search : ''), {
+      replaceState: false,
+      keepFocus: true,
+    });
+  }
+
+  async function saveDrawer(patch: Record<string, unknown>) {
+    if (!activeRow) {
+      return;
+    }
+    try {
+      await api.adminUpdateRow(config.id, pkValuesFor(activeRow), patch);
+    } catch (caught) {
+      error = String(caught);
+      throw caught;
+    }
+  }
+
+  async function deleteDrawer() {
+    if (!activeRow) {
+      return;
+    }
+    try {
+      await api.adminDeleteRows(config.id, [pkValuesFor(activeRow)]);
+      await load();
+    } catch (caught) {
       error = String(caught);
     }
   }
@@ -72,7 +144,9 @@
 </div>
 
 {#if error}
-  <div class="mx-6 mb-4 rounded-md border border-destructive/30 bg-destructive/10 px-4 py-2 text-sm text-destructive-foreground">
+  <div
+    class="mx-6 mb-4 rounded-md border border-destructive/30 bg-destructive/10 px-4 py-2 text-sm text-destructive-foreground"
+  >
     {error}
   </div>
 {/if}
@@ -89,10 +163,11 @@
           {#each visibleColumns as column (column.key)}
             <th class="px-2 py-2 text-left font-medium">{columnLabel(column)}</th>
           {/each}
+          <th class="px-2 py-2 text-right font-medium">Open</th>
         </tr>
       </thead>
       <tbody>
-        {#each rows as row (config.primaryKey.map((k) => row[k]).join(':'))}
+        {#each rows as row (pkStringFor(row))}
           <tr class="border-b border-border/50 hover:bg-accent/20">
             {#each visibleColumns as column (column.key)}
               <td class="px-2 py-1.5 align-middle">
@@ -103,9 +178,27 @@
                 />
               </td>
             {/each}
+            <td class="px-2 py-1.5 text-right">
+              <button
+                type="button"
+                onclick={() => openDrawer(row)}
+                class="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+              >
+                Edit…
+              </button>
+            </td>
           </tr>
         {/each}
       </tbody>
     </table>
   {/if}
 </div>
+
+<RowDrawer
+  bind:open={drawerOpen}
+  {config}
+  row={activeRow}
+  onClose={closeDrawer}
+  onSave={saveDrawer}
+  onDelete={deleteDrawer}
+/>

--- a/src/lib/admin/FkChip.svelte
+++ b/src/lib/admin/FkChip.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+  import { api } from '$lib/api';
+  import type { TableId } from './tables';
+
+  type Props = {
+    table: TableId;
+    labelColumn: string;
+    value: unknown;
+  };
+
+  let { table, labelColumn, value }: Props = $props();
+
+  let label = $state<string | null>(null);
+  let loading = $state(false);
+
+  $effect(() => {
+    if (value === null || value === undefined) {
+      label = null;
+      return;
+    }
+
+    const cacheKey = `${table}:${labelColumn}:${JSON.stringify(value)}`;
+    const cached = labelCache.get(cacheKey);
+    if (cached !== undefined) {
+      label = cached;
+      return;
+    }
+
+    loading = true;
+    void api
+      .adminFkLabel(table, labelColumn, value)
+      .then((result) => {
+        labelCache.set(cacheKey, result);
+        label = result;
+      })
+      .catch(() => {
+        label = null;
+      })
+      .finally(() => {
+        loading = false;
+      });
+  });
+</script>
+
+{#if value === null || value === undefined}
+  <span class="text-muted-foreground">—</span>
+{:else}
+  <a
+    href={`/admin/${table}?row=${encodeURIComponent(String(value))}`}
+    class="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2 py-0.5 text-xs text-foreground transition-colors hover:bg-accent"
+  >
+    <span class="font-mono text-muted-foreground">#{String(value)}</span>
+    {#if loading}
+      <span class="text-muted-foreground">…</span>
+    {:else if label}
+      <span class="max-w-[18ch] truncate">{label}</span>
+    {/if}
+  </a>
+{/if}
+
+<script lang="ts" module>
+  const labelCache = new Map<string, string | null>();
+</script>

--- a/src/lib/admin/RowDrawer.svelte
+++ b/src/lib/admin/RowDrawer.svelte
@@ -1,0 +1,115 @@
+<script lang="ts">
+  import { Button } from '$lib/components/ui/button';
+  import * as Sheet from '$lib/components/ui/sheet';
+  import * as AlertDialog from '$lib/components/ui/alert-dialog';
+  import { Trash2 } from '$lib/lucide';
+  import AdminCell from './AdminCell.svelte';
+  import { columnLabel, type TableConfig } from './tables';
+
+  type Props = {
+    open: boolean;
+    config: TableConfig;
+    row: Record<string, unknown> | null;
+    onClose: () => void;
+    onSave: (patch: Record<string, unknown>) => Promise<void>;
+    onDelete: () => Promise<void>;
+  };
+
+  let {
+    open = $bindable(),
+    config,
+    row,
+    onClose,
+    onSave,
+    onDelete,
+  }: Props = $props();
+
+  let confirmDeleteOpen = $state(false);
+  let deleting = $state(false);
+
+  async function handleCellSave(columnKey: string, next: unknown) {
+    if (!row) {
+      return;
+    }
+    await onSave({ [columnKey]: next });
+    row[columnKey] = next;
+  }
+
+  async function handleDelete() {
+    if (!row) {
+      return;
+    }
+    deleting = true;
+    try {
+      await onDelete();
+      confirmDeleteOpen = false;
+      onClose();
+    } finally {
+      deleting = false;
+    }
+  }
+</script>
+
+<Sheet.Root bind:open>
+  <Sheet.Content side="right" class="w-full overflow-y-auto sm:max-w-lg">
+    <Sheet.Header>
+      <Sheet.Title>{config.label} · row</Sheet.Title>
+      <Sheet.Description>
+        {row
+          ? config.primaryKey.map((pk) => `${pk}=${row[pk]}`).join(', ')
+          : ''}
+      </Sheet.Description>
+    </Sheet.Header>
+
+    {#if row}
+      <div class="mt-6 flex flex-col gap-4">
+        {#each config.columns as column (column.key)}
+          <div class="flex flex-col gap-1">
+            <span class="text-xs uppercase tracking-wide text-muted-foreground">
+              {columnLabel(column)}
+            </span>
+            <div class="min-h-[2rem]">
+              <AdminCell
+                {column}
+                value={row[column.key]}
+                onSave={(next) => handleCellSave(column.key, next)}
+              />
+            </div>
+          </div>
+        {/each}
+      </div>
+
+      <Sheet.Footer class="mt-8 flex items-center justify-between gap-2">
+        <AlertDialog.Root bind:open={confirmDeleteOpen}>
+          <AlertDialog.Trigger
+            class="inline-flex h-9 items-center justify-center gap-2 rounded-md bg-destructive px-3 py-2 text-sm font-medium text-destructive-foreground shadow-sm transition-colors hover:bg-destructive/90"
+          >
+            <Trash2 class="size-4" />
+            Delete row
+          </AlertDialog.Trigger>
+          <AlertDialog.Content>
+            <AlertDialog.Header>
+              <AlertDialog.Title>Delete this row?</AlertDialog.Title>
+              <AlertDialog.Description>
+                {config.label} ·
+                {config.primaryKey.map((pk) => `${pk}=${row?.[pk]}`).join(', ')}
+              </AlertDialog.Description>
+            </AlertDialog.Header>
+            <AlertDialog.Footer>
+              <AlertDialog.Cancel disabled={deleting}>Cancel</AlertDialog.Cancel>
+              <AlertDialog.Action
+                variant="destructive"
+                onclick={handleDelete}
+                disabled={deleting}
+              >
+                {deleting ? 'Deleting…' : 'Delete'}
+              </AlertDialog.Action>
+            </AlertDialog.Footer>
+          </AlertDialog.Content>
+        </AlertDialog.Root>
+
+        <Button variant="ghost" onclick={onClose}>Close</Button>
+      </Sheet.Footer>
+    {/if}
+  </Sheet.Content>
+</Sheet.Root>

--- a/src/lib/admin/tables.ts
+++ b/src/lib/admin/tables.ts
@@ -25,10 +25,19 @@ export interface TableConfig {
   columns: ColumnConfig[];
 }
 
-// Only `shows` is configured for now — the other six configs land in the
-// admin PR 3 alongside the drawer + FK chips. Adding a new table here
-// before then will work but it'll render with default behaviour only.
-export const TABLES: Partial<Record<TableId, TableConfig>> = {
+export const TABLES: Record<TableId, TableConfig> = {
+  libraries: {
+    id: 'libraries',
+    label: 'Libraries',
+    primaryKey: ['id'],
+    defaultSort: { column: 'id', direction: 'asc' },
+    columns: [
+      { key: 'id', readonly: true },
+      { key: 'path' },
+      { key: 'kind' },
+      { key: 'added_at', kind: 'datetime', readonly: true },
+    ],
+  },
   shows: {
     id: 'shows',
     label: 'Shows',
@@ -48,6 +57,81 @@ export const TABLES: Partial<Record<TableId, TableConfig>> = {
       { key: 'folder_path' },
       { key: 'fingerprint', readonly: true },
       { key: 'added_at', kind: 'datetime', readonly: true },
+    ],
+  },
+  movies: {
+    id: 'movies',
+    label: 'Movies',
+    primaryKey: ['id'],
+    defaultSort: { column: 'title', direction: 'asc' },
+    columns: [
+      { key: 'id', readonly: true },
+      { key: 'title' },
+      { key: 'year' },
+      { key: 'library_id', fkTable: 'libraries', fkLabel: 'path' },
+      { key: 'provider' },
+      { key: 'rating', readonly: true },
+      { key: 'runtime_minutes' },
+      { key: 'metadata_locked', kind: 'boolean' },
+      { key: 'genres', kind: 'json', hideInGrid: true },
+      { key: 'top_cast', kind: 'json', hideInGrid: true },
+      { key: 'overview', kind: 'text', hideInGrid: true },
+      { key: 'path', hideInGrid: true },
+      { key: 'added_at', kind: 'datetime', readonly: true },
+    ],
+  },
+  episodes: {
+    id: 'episodes',
+    label: 'Episodes',
+    primaryKey: ['id'],
+    defaultSort: { column: 'show_id', direction: 'asc' },
+    columns: [
+      { key: 'id', readonly: true },
+      { key: 'show_id', fkTable: 'shows', fkLabel: 'title' },
+      { key: 'season' },
+      { key: 'episode' },
+      { key: 'title' },
+      { key: 'duration_seconds' },
+      { key: 'path', hideInGrid: true },
+      { key: 'added_at', kind: 'datetime', readonly: true },
+    ],
+  },
+  watch_history: {
+    id: 'watch_history',
+    label: 'Watch history',
+    primaryKey: ['media_kind', 'media_id'],
+    defaultSort: { column: 'last_watched_at', direction: 'desc' },
+    columns: [
+      { key: 'media_kind' },
+      { key: 'media_id' },
+      { key: 'progress_seconds' },
+      { key: 'duration_seconds' },
+      { key: 'watched', kind: 'boolean' },
+      { key: 'last_watched_at', kind: 'datetime' },
+    ],
+  },
+  metadata_jobs: {
+    id: 'metadata_jobs',
+    label: 'Metadata jobs',
+    primaryKey: ['kind', 'media_id'],
+    defaultSort: { column: 'enqueued_at', direction: 'desc' },
+    columns: [
+      { key: 'kind' },
+      { key: 'media_id' },
+      { key: 'enqueued_at', kind: 'datetime', readonly: true },
+      { key: 'attempts' },
+      { key: 'last_error', hideInGrid: true },
+      { key: 'next_attempt_at', kind: 'datetime' },
+    ],
+  },
+  app_settings: {
+    id: 'app_settings',
+    label: 'App settings',
+    primaryKey: ['key'],
+    defaultSort: { column: 'key', direction: 'asc' },
+    columns: [
+      { key: 'key' },
+      { key: 'value' },
     ],
   },
 };

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
   import { ChevronRight } from '$lib/lucide';
-  import { TABLES, type TableConfig } from '$lib/admin/tables';
+  import { TABLES } from '$lib/admin/tables';
 
-  const entries = Object.values(TABLES).filter(
-    (config): config is TableConfig => config !== undefined,
-  );
+  const entries = Object.values(TABLES);
 </script>
 
 <div class="mx-auto max-w-3xl px-6 py-8">


### PR DESCRIPTION
## Summary
- Configs for the remaining six tables (libraries, movies, episodes, watch_history, metadata_jobs, app_settings).
- ``<RowDrawer>`` with full per-column edit + delete (uses AlertDialog).
- ``<FkChip>`` renders foreign-key columns as clickable chips with a session-level label cache.
- Drawer state synced via ``?row=<pk>`` query string. Composite keys serialise as ``part1:part2``.

## Test plan
- [ ] Open ``/admin`` — all seven tables listed.
- [ ] Open ``/admin/episodes`` — ``show_id`` renders as a chip with the show's title.
- [ ] Click the chip → lands on ``/admin/shows?row=<id>`` with the drawer open.
- [ ] Click ``Edit…`` on any row → drawer opens with every column.
- [ ] Edit ``overview`` in the drawer → save → grid updates.
- [ ] Delete a row from the drawer → confirm → row disappears.
- [ ] Composite-key tables (``watch_history``, ``metadata_jobs``) — open a row, edit, delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)