### PR TITLE
Fix metadata worker startup panic (tokio::spawn → tauri::async_runtime::spawn)

### DIFF
--- a/src-tauri/src/metadata/worker.rs
+++ b/src-tauri/src/metadata/worker.rs
@@ -21,7 +21,10 @@ pub fn spawn(pool: SqlitePool, http: reqwest::Client, app: AppHandle) -> Arc<Not
     let notify = Arc::new(Notify::new());
     let notify_clone = notify.clone();
 
-    tokio::spawn(async move {
+    // Tauri's setup closure runs outside a tokio runtime context, so a bare
+    // `tokio::spawn` panics. `tauri::async_runtime::spawn` is the same
+    // multi-threaded tokio runtime Tauri uses for command handlers.
+    tauri::async_runtime::spawn(async move {
         if let Err(error) = run(pool, http, app, notify_clone).await {
             eprintln!("metadata worker exited with error: {error}");
         }


### PR DESCRIPTION
## Summary
- Replace ``tokio::spawn`` with ``tauri::async_runtime::spawn`` in ``metadata::worker::spawn`` so it runs inside Tauri's tokio runtime instead of expecting an ambient one.

## Why
Tauri's ``setup`` closure executes synchronously without a tokio reactor on the current thread, so ``tokio::spawn`` panicked at startup:

```
thread 'main' panicked at src\metadata\worker.rs:24:5
process didn't exit successfully: target\debug\rustflix.exe (exit code: 101)
```

``tauri::async_runtime::spawn`` reaches into Tauri's own runtime and is the right primitive here. Same behaviour once the future runs; only the dispatch differs.

## Test plan
- [ ] Launch ``pnpm tauri:dev`` — app window opens.
- [ ] With a TMDB key configured, scanning a library still drains the queue (worker is up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)