### PR TITLE
Named PlayResult interface in api.ts

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -56,6 +56,10 @@ export interface Show {
   metadata_locked: number;
 }
 
+export interface PlayResult {
+  session_id: number;
+}
+
 export interface MetadataStatusCounts {
   pending: number;
   failed: number;
@@ -150,9 +154,9 @@ export const api = {
 
   checkMpv: () => invoke<boolean>('check_mpv'),
   playMovie: (id: number, resume?: number) =>
-    invoke<{ session_id: number }>('play_movie', { id, resume }),
+    invoke<PlayResult>('play_movie', { id, resume }),
   playEpisode: (id: number, resume?: number) =>
-    invoke<{ session_id: number }>('play_episode', { id, resume }),
+    invoke<PlayResult>('play_episode', { id, resume }),
 
   updateShowMetadata: (id: number, patch: MetadataPatch) =>
     invoke<Show>('update_show_metadata', { id, ...patch }),


### PR DESCRIPTION
## Summary
- Promote the inline ``{ session_id: number }`` used by ``playMovie`` / ``playEpisode`` to a named ``PlayResult`` interface, mirroring the Rust ``PlayResult`` struct in ``player.rs``.

## Why
Code-review nitpick — no behaviour change, just removes the copy-paste and keeps the TS / Rust shapes in lockstep names.

## Test plan
- [ ] ``pnpm check`` shows the same single pre-existing error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)