### PR TITLE
CLAUDE.md style cleanup sweep (and the last svelte-check error)

### DIFF
--- a/src-tauri/src/player.rs
+++ b/src-tauri/src/player.rs
@@ -41,7 +41,7 @@ pub async fn check_mpv() -> AppResult<()> {
         .stderr(Stdio::null())
         .status()
         .await
-        .map(|s| s.success())
+        .map(|status| status.success())
         .unwrap_or(false);
     if ok {
         Ok(())

--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -32,11 +32,11 @@ pub async fn add_library(pool: &SqlitePool, path: &str, kind: LibraryKind) -> Ap
 }
 
 pub async fn remove_library(pool: &SqlitePool, id: i64) -> AppResult<()> {
-    let res = sqlx::query("DELETE FROM libraries WHERE id = ?1")
+    let result = sqlx::query("DELETE FROM libraries WHERE id = ?1")
         .bind(id)
         .execute(pool)
         .await?;
-    if res.rows_affected() == 0 {
+    if result.rows_affected() == 0 {
         return Err(AppError::LibraryNotFound(id));
     }
     Ok(())

--- a/src-tauri/src/scanner.rs
+++ b/src-tauri/src/scanner.rs
@@ -64,8 +64,12 @@ pub fn fingerprint(name: &str) -> String {
 
 fn is_video_file(path: &Path) -> bool {
     path.extension()
-        .and_then(|e| e.to_str())
-        .map(|e| VIDEO_EXTS.iter().any(|v| v.eq_ignore_ascii_case(e)))
+        .and_then(|extension| extension.to_str())
+        .map(|extension| {
+            VIDEO_EXTS
+                .iter()
+                .any(|candidate| candidate.eq_ignore_ascii_case(extension))
+        })
         .unwrap_or(false)
 }
 
@@ -218,15 +222,15 @@ async fn find_poster_in(dir: &Path) -> Option<PathBuf> {
 
         let Some(stem) = path
             .file_stem()
-            .and_then(|s| s.to_str())
-            .map(|s| s.to_lowercase())
+            .and_then(|name| name.to_str())
+            .map(|name| name.to_lowercase())
         else {
             continue;
         };
         let Some(ext) = path
             .extension()
-            .and_then(|e| e.to_str())
-            .map(|e| e.to_lowercase())
+            .and_then(|extension| extension.to_str())
+            .map(|extension| extension.to_lowercase())
         else {
             continue;
         };
@@ -239,9 +243,17 @@ async fn find_poster_in(dir: &Path) -> Option<PathBuf> {
         }
     }
 
-    candidates.sort_by_key(|p| {
-        let stem = p.file_stem().and_then(|s| s.to_str()).unwrap_or("").to_lowercase();
-        let ext = p.extension().and_then(|e| e.to_str()).unwrap_or("").to_lowercase();
+    candidates.sort_by_key(|path| {
+        let stem = path
+            .file_stem()
+            .and_then(|name| name.to_str())
+            .unwrap_or("")
+            .to_lowercase();
+        let ext = path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .unwrap_or("")
+            .to_lowercase();
         let basename_rank = POSTER_BASENAMES
             .iter()
             .position(|candidate| *candidate == stem)
@@ -361,13 +373,13 @@ pub async fn scan_library(
             .follow_links(true)
             .into_iter()
             .flatten()
-            .filter(|e| e.file_type().is_file())
-            .map(|e| e.into_path())
-            .filter(|p| is_video_file(p))
+            .filter(|entry| entry.file_type().is_file())
+            .map(|entry| entry.into_path())
+            .filter(|path| is_video_file(path))
             .collect()
     })
     .await
-    .map_err(|e| crate::error::AppError::Other(e.to_string()))?;
+    .map_err(|error| crate::error::AppError::Other(error.to_string()))?;
 
     for path in paths {
         let path_str = path.to_string_lossy().to_string();
@@ -505,7 +517,7 @@ pub async fn scan_library(
 
                 touched_shows.insert(show_id);
 
-                let res = sqlx::query(
+                let result = sqlx::query(
                     "INSERT OR IGNORE INTO episodes (show_id, season, episode, title, path)
                      VALUES (?1, ?2, ?3, ?4, ?5)",
                 )
@@ -517,7 +529,7 @@ pub async fn scan_library(
                 .execute(pool)
                 .await?;
 
-                if res.rows_affected() > 0 {
+                if result.rows_affected() > 0 {
                     report.episodes_added += 1;
                     if created_new_show {
                         report.shows_added += 1;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -222,14 +222,27 @@ export const api = {
 };
 
 export function formatRuntime(seconds: number | null | undefined): string {
-  if (!seconds || seconds <= 0) return '';
-  const h = Math.floor(seconds / 3600);
-  const m = Math.floor((seconds % 3600) / 60);
-  if (h > 0) return `${h}h ${m}m`;
-  return `${m}m`;
+  if (!seconds || seconds <= 0) {
+    return '';
+  }
+
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+  return `${minutes}m`;
 }
 
-export function progressPct(p: { progress_seconds: number; duration_seconds: number | null }): number {
-  if (!p.duration_seconds || p.duration_seconds <= 0) return 0;
-  return Math.min(100, Math.max(0, (p.progress_seconds / p.duration_seconds) * 100));
+export function progressPct(
+  playback: { progress_seconds: number; duration_seconds: number | null },
+): number {
+  if (!playback.duration_seconds || playback.duration_seconds <= 0) {
+    return 0;
+  }
+  return Math.min(
+    100,
+    Math.max(0, (playback.progress_seconds / playback.duration_seconds) * 100),
+  );
 }

--- a/src/lib/components/MediaRow.svelte
+++ b/src/lib/components/MediaRow.svelte
@@ -13,7 +13,9 @@
   let scroller: HTMLDivElement | null = $state(null);
 
   function scrollBy(dir: 1 | -1) {
-    if (!scroller) return;
+    if (!scroller) {
+      return;
+    }
     scroller.scrollBy({ left: dir * scroller.clientWidth * 0.8, behavior: 'smooth' });
   }
 </script>

--- a/src/lib/components/TopNav.svelte
+++ b/src/lib/components/TopNav.svelte
@@ -9,7 +9,9 @@
   ];
 
   function isActive(href: string, current: string): boolean {
-    if (href === '/') return current === '/';
+    if (href === '/') {
+      return current === '/';
+    }
     return current === href || current.startsWith(href + '/');
   }
 </script>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -24,18 +24,18 @@
   async function load() {
     loading = true;
     try {
-      const libs = await api.listLibraries();
-      hasLibraries = libs.length > 0;
-      const [m, s, c] = await Promise.all([
+      const libraries = await api.listLibraries();
+      hasLibraries = libraries.length > 0;
+      const [loadedMovies, loadedShows, loadedContinue] = await Promise.all([
         api.listMovies(),
         api.listShows(),
         api.continueWatching(),
       ]);
-      movies = m;
-      shows = s;
-      continueItems = c;
-    } catch (e) {
-      console.error(e);
+      movies = loadedMovies;
+      shows = loadedShows;
+      continueItems = loadedContinue;
+    } catch (caught) {
+      console.error(caught);
     } finally {
       loading = false;
     }
@@ -54,11 +54,13 @@
   const recentMovies = $derived([...movies].sort((a, b) => b.added_at - a.added_at).slice(0, 20));
   const recentShows = $derived([...shows].sort((a, b) => b.added_at - a.added_at).slice(0, 20));
 
-  function showSubtitle(s: Show): string {
-    const watched = s.watched_count;
-    const total = s.episode_count;
-    if (total === 0) return s.year ? `${s.year}` : '';
-    return `${watched}/${total} watched${s.year ? ` · ${s.year}` : ''}`;
+  function showSubtitle(show: Show): string {
+    const watched = show.watched_count;
+    const total = show.episode_count;
+    if (total === 0) {
+      return show.year ? `${show.year}` : '';
+    }
+    return `${watched}/${total} watched${show.year ? ` · ${show.year}` : ''}`;
   }
 </script>
 

--- a/src/routes/films/+page.svelte
+++ b/src/routes/films/+page.svelte
@@ -15,8 +15,8 @@
     loading = true;
     try {
       movies = await api.listMovies();
-    } catch (e) {
-      console.error(e);
+    } catch (caught) {
+      console.error(caught);
     } finally {
       loading = false;
     }
@@ -25,7 +25,7 @@
   const filtered = $derived(
     query.trim() === ''
       ? movies
-      : movies.filter((m) => m.title.toLowerCase().includes(query.toLowerCase())),
+      : movies.filter((movie) => movie.title.toLowerCase().includes(query.toLowerCase())),
   );
 </script>
 

--- a/src/routes/films/[id]/+page.svelte
+++ b/src/routes/films/[id]/+page.svelte
@@ -18,7 +18,9 @@
   const id = $derived(Number($page.params.id));
 
   $effect(() => {
-    if (!Number.isFinite(id)) return;
+    if (!Number.isFinite(id)) {
+      return;
+    }
     void load(id);
   });
 
@@ -27,21 +29,23 @@
     error = null;
     try {
       movie = await api.getMovie(movieId);
-    } catch (e) {
-      error = String(e);
+    } catch (caught) {
+      error = String(caught);
     } finally {
       loading = false;
     }
   }
 
   async function play(fromStart = false) {
-    if (!movie) return;
+    if (!movie) {
+      return;
+    }
     playing = true;
     try {
       await api.playMovie(movie.id, fromStart ? 0 : undefined);
       await load(movie.id);
-    } catch (e) {
-      error = String(e);
+    } catch (caught) {
+      error = String(caught);
     } finally {
       playing = false;
     }

--- a/src/routes/series/+page.svelte
+++ b/src/routes/series/+page.svelte
@@ -15,8 +15,8 @@
     loading = true;
     try {
       shows = await api.listShows();
-    } catch (e) {
-      console.error(e);
+    } catch (caught) {
+      console.error(caught);
     } finally {
       loading = false;
     }
@@ -25,12 +25,14 @@
   const filtered = $derived(
     query.trim() === ''
       ? shows
-      : shows.filter((s) => s.title.toLowerCase().includes(query.toLowerCase())),
+      : shows.filter((show) => show.title.toLowerCase().includes(query.toLowerCase())),
   );
 
-  function subtitle(s: Show): string {
-    if (s.episode_count === 0) return s.year ? String(s.year) : '';
-    return `${s.watched_count}/${s.episode_count} watched`;
+  function subtitle(show: Show): string {
+    if (show.episode_count === 0) {
+      return show.year ? String(show.year) : '';
+    }
+    return `${show.watched_count}/${show.episode_count} watched`;
   }
 </script>
 

--- a/src/routes/series/[id]/+page.svelte
+++ b/src/routes/series/[id]/+page.svelte
@@ -23,7 +23,9 @@
   const id = $derived(Number($page.params.id));
 
   $effect(() => {
-    if (!Number.isFinite(id)) return;
+    if (!Number.isFinite(id)) {
+      return;
+    }
     void load(id);
   });
 
@@ -35,17 +37,19 @@
       if (selectedSeason === null && seasons.length > 0) {
         selectedSeason = seasons[0].season;
       }
-    } catch (e) {
-      error = String(e);
+    } catch (caught) {
+      error = String(caught);
     } finally {
       loading = false;
     }
   }
 
   const nextUp = $derived.by(() => {
-    for (const s of seasons) {
-      for (const e of s.episodes) {
-        if (!e.watched) return e;
+    for (const season of seasons) {
+      for (const episode of season.episodes) {
+        if (!episode.watched) {
+          return episode;
+        }
       }
     }
     return null;
@@ -54,9 +58,11 @@
   async function playEpisode(epId: number, fromStart = false) {
     try {
       await api.playEpisode(epId, fromStart ? 0 : undefined);
-      if (show) await load(show.id);
-    } catch (e) {
-      error = String(e);
+      if (show) {
+        await load(show.id);
+      }
+    } catch (caught) {
+      error = String(caught);
     }
   }
 
@@ -149,7 +155,7 @@
   }
 
   const activeSeason = $derived(
-    seasons.find((s) => s.season === selectedSeason) ?? seasons[0] ?? null,
+    seasons.find((season) => season.season === selectedSeason) ?? seasons[0] ?? null,
   );
 </script>
 
@@ -206,16 +212,16 @@
 
     {#if seasons.length > 1}
       <div class="mb-4 flex flex-wrap gap-2">
-        {#each seasons as s (s.season)}
-          {@const isActive = s.season === activeSeason?.season}
+        {#each seasons as season (season.season)}
+          {@const isActive = season.season === activeSeason?.season}
           <button
             type="button"
-            onclick={() => (selectedSeason = s.season)}
+            onclick={() => (selectedSeason = season.season)}
             class="rounded-md px-3 py-1.5 text-sm font-medium transition-colors {isActive
               ? 'bg-primary text-primary-foreground'
               : 'bg-secondary text-secondary-foreground hover:bg-accent'}"
           >
-            Season {s.season}
+            Season {season.season}
           </button>
         {/each}
       </div>
@@ -225,7 +231,11 @@
       bind:open={mergeOpen}
       {show}
       onClose={() => (mergeOpen = false)}
-      onMerged={() => show && load(show.id)}
+      onMerged={() => {
+        if (show) {
+          void load(show.id);
+        }
+      }}
     />
 
     {#if activeSeason}

--- a/src/routes/settings/libraries/+page.svelte
+++ b/src/routes/settings/libraries/+page.svelte
@@ -27,8 +27,8 @@
     loading = true;
     try {
       [libraries, mpvOk] = await Promise.all([api.listLibraries(), api.checkMpv()]);
-    } catch (e) {
-      error = String(e);
+    } catch (caught) {
+      error = String(caught);
     } finally {
       loading = false;
     }
@@ -37,13 +37,15 @@
   async function add() {
     error = null;
     const path = await api.pickFolder();
-    if (!path) return;
+    if (!path) {
+      return;
+    }
     busy = true;
     try {
       await api.addLibrary(path, kind);
       await load();
-    } catch (e) {
-      error = String(e);
+    } catch (caught) {
+      error = String(caught);
     } finally {
       busy = false;
     }
@@ -53,9 +55,9 @@
     busy = true;
     try {
       await api.removeLibrary(id);
-      libraries = libraries.filter((l) => l.id !== id);
-    } catch (e) {
-      error = String(e);
+      libraries = libraries.filter((library) => library.id !== id);
+    } catch (caught) {
+      error = String(caught);
     } finally {
       busy = false;
     }
@@ -67,8 +69,8 @@
     try {
       lastReport = await api.scanLibraries();
       await load();
-    } catch (e) {
-      error = String(e);
+    } catch (caught) {
+      error = String(caught);
     } finally {
       busy = false;
     }
@@ -162,17 +164,17 @@
       </div>
     {:else}
       <ul class="divide-y divide-border rounded-lg border border-border bg-card">
-        {#each libraries as lib (lib.id)}
+        {#each libraries as library (library.id)}
           <li class="flex items-center gap-4 px-5 py-4">
             <div class="min-w-0 flex-1">
-              <div class="truncate font-medium">{lib.path}</div>
+              <div class="truncate font-medium">{library.path}</div>
               <div class="text-xs uppercase tracking-wide text-muted-foreground">
-                {lib.kind}
+                {library.kind}
               </div>
             </div>
             <button
               type="button"
-              onclick={() => remove(lib.id)}
+              onclick={() => remove(library.id)}
               disabled={busy}
               class="inline-flex size-9 items-center justify-center rounded-md text-muted-foreground transition hover:bg-destructive/20 hover:text-destructive-foreground"
               aria-label="Remove library"


### PR DESCRIPTION
## Summary
- ``catch (e)`` → ``catch (caught)`` across every route + lib file.
- Block-bodied every one-line ``if (X) return;`` flagged by the audit.
- Renamed cryptic short loop / callback names: ``(s) → (season)`` / ``(show)``, ``(m) → (movie)``, ``(l) → (library)``, ``(p) → (path/playback)``; Rust closures ``|e| → |error|`` (or ``|extension|`` / ``|entry|`` where appropriate).
- ``let res`` → ``let result`` in ``queries.rs`` and ``scanner.rs``.
- Rewrote ``formatRuntime`` / ``progressPct`` / ``nextUp`` / ``showSubtitle`` / ``subtitle`` with full names + block-bodied guards.
- Closed the long-standing pre-existing svelte-check error in ``series/[id]/+page.svelte`` (``onMerged`` was returning ``Promise<void> | null``; now wraps in a void-returning block).

## Why
The project-wide review last session listed ~30 CLAUDE.md violations the codebase had accumulated. Mechanical cleanup. The accidental win is that the ``MergeShowSheet`` ``onMerged`` callback now type-checks correctly, which means ``pnpm check`` is **clean for the first time in the project**.

## Test plan
- [ ] ``pnpm check`` — 0 errors.
- [ ] ``cargo test`` — 28 passing, no regressions.
- [ ] App still launches and the home screen / library / settings / admin / merge sheet all behave identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)