### PR TITLE
Metadata fix/45: IMDB module + worker dispatch + hand-link fast path

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -337,15 +337,26 @@ pub async fn metadata_search(
     kind: String,
     query: String,
     year: Option<i32>,
+    provider: String,
 ) -> AppResult<Vec<crate::metadata::matching::MatchCandidate>> {
-    let api_key = queries::get_app_setting(&db, "tmdb_api_key")
-        .await?
-        .ok_or_else(|| AppError::Other("no TMDB key configured".to_string()))?;
+    match provider.as_str() {
+        "tmdb" => {
+            let api_key = queries::get_app_setting(&db, "tmdb_api_key")
+                .await?
+                .ok_or_else(|| AppError::Other("no TMDB key configured".to_string()))?;
 
-    match kind.as_str() {
-        "movie" => crate::metadata::tmdb::search_movie(&http, &api_key, &query, year).await,
-        "show" => crate::metadata::tmdb::search_show(&http, &api_key, &query, year).await,
-        other => Err(AppError::Other(format!("unknown kind: {other}"))),
+            match kind.as_str() {
+                "movie" => crate::metadata::tmdb::search_movie(&http, &api_key, &query, year).await,
+                "show" => crate::metadata::tmdb::search_show(&http, &api_key, &query, year).await,
+                other => Err(AppError::Other(format!("unknown kind: {other}"))),
+            }
+        }
+        "imdb" => match kind.as_str() {
+            "movie" => crate::metadata::imdb::search_movie(&http, &query, year).await,
+            "show" => crate::metadata::imdb::search_show(&http, &query, year).await,
+            other => Err(AppError::Other(format!("unknown kind: {other}"))),
+        },
+        other => Err(AppError::Other(format!("unknown provider: {other}"))),
     }
 }
 
@@ -355,8 +366,13 @@ pub async fn link_metadata(
     db: State<'_, Db>,
     kind: String,
     media_id: i64,
+    provider: String,
     provider_id: String,
 ) -> AppResult<()> {
+    if !matches!(provider.as_str(), "tmdb" | "imdb") {
+        return Err(AppError::Other(format!("unknown provider: {provider}")));
+    }
+
     let table = match kind.as_str() {
         "show" => "shows",
         "movie" => "movies",
@@ -364,10 +380,11 @@ pub async fn link_metadata(
     };
 
     sqlx::query(&format!(
-        "UPDATE {table} SET provider = 'tmdb', provider_id = ?2, metadata_locked = 0
+        "UPDATE {table} SET provider = ?2, provider_id = ?3, metadata_locked = 0
          WHERE id = ?1"
     ))
     .bind(media_id)
+    .bind(&provider)
     .bind(&provider_id)
     .execute(&*db)
     .await?;

--- a/src-tauri/src/metadata/apply.rs
+++ b/src-tauri/src/metadata/apply.rs
@@ -207,3 +207,267 @@ fn compute_poster_extension(
 fn parse_year(date: Option<&str>) -> Option<i32> {
     date.and_then(|d| d.get(0..4)).and_then(|year| year.parse().ok())
 }
+
+use crate::metadata::imdb::{PosterSize, PrincipalCredits, RatingsNode, TitleNode};
+
+pub async fn apply_imdb_movie_details(
+    conn: &mut SqliteConnection,
+    movie_id: i64,
+    details: &TitleNode,
+) -> AppResult<Option<(PosterSize, String, String)>> {
+    let current_poster_origin: Option<String> =
+        sqlx::query_scalar("SELECT poster_origin FROM movies WHERE id = ?1")
+            .bind(movie_id)
+            .fetch_one(&mut *conn)
+            .await?;
+
+    let download_target = compute_imdb_poster(
+        current_poster_origin.as_deref(),
+        details.primary_image.as_ref().map(|image| image.url.as_str()),
+        movie_id,
+        "movie",
+    );
+
+    let overview = details
+        .plot
+        .as_ref()
+        .and_then(|plot| plot.plot_text.as_ref())
+        .and_then(|text| text.plain_text.as_deref());
+    let year = details.release_year.as_ref().and_then(|release| release.year);
+    let rating = imdb_rating(&details.ratings_summary);
+    let genres_json = serde_json::to_string(
+        &details
+            .genres
+            .as_ref()
+            .map(|wrapper| {
+                wrapper
+                    .genres
+                    .iter()
+                    .map(|genre| genre.text.clone())
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default(),
+    )
+    .unwrap_or_else(|_| "[]".to_string());
+    let cast_json = build_imdb_cast_json(&details.principal_credits);
+    let runtime_minutes = details
+        .runtime
+        .as_ref()
+        .and_then(|runtime| runtime.seconds)
+        .map(|seconds| seconds / 60);
+
+    if let Some((_size, _url, local_path)) = download_target.as_ref() {
+        sqlx::query(
+            "UPDATE movies SET
+                 provider = 'imdb',
+                 provider_id = ?1,
+                 overview = COALESCE(?2, overview),
+                 year = COALESCE(?3, year),
+                 rating = ?4,
+                 genres = ?5,
+                 top_cast = ?6,
+                 runtime_minutes = COALESCE(?7, runtime_minutes),
+                 poster_path = ?8,
+                 poster_origin = 'imdb',
+                 metadata_synced_at = strftime('%s','now')
+             WHERE id = ?9",
+        )
+        .bind(&details.id)
+        .bind(overview)
+        .bind(year)
+        .bind(rating)
+        .bind(&genres_json)
+        .bind(&cast_json)
+        .bind(runtime_minutes)
+        .bind(local_path)
+        .bind(movie_id)
+        .execute(&mut *conn)
+        .await?;
+    } else {
+        sqlx::query(
+            "UPDATE movies SET
+                 provider = 'imdb',
+                 provider_id = ?1,
+                 overview = COALESCE(?2, overview),
+                 year = COALESCE(?3, year),
+                 rating = ?4,
+                 genres = ?5,
+                 top_cast = ?6,
+                 runtime_minutes = COALESCE(?7, runtime_minutes),
+                 metadata_synced_at = strftime('%s','now')
+             WHERE id = ?8",
+        )
+        .bind(&details.id)
+        .bind(overview)
+        .bind(year)
+        .bind(rating)
+        .bind(&genres_json)
+        .bind(&cast_json)
+        .bind(runtime_minutes)
+        .bind(movie_id)
+        .execute(&mut *conn)
+        .await?;
+    }
+
+    Ok(download_target)
+}
+
+pub async fn apply_imdb_show_details(
+    conn: &mut SqliteConnection,
+    show_id: i64,
+    details: &TitleNode,
+) -> AppResult<Option<(PosterSize, String, String)>> {
+    let current_poster_origin: Option<String> =
+        sqlx::query_scalar("SELECT poster_origin FROM shows WHERE id = ?1")
+            .bind(show_id)
+            .fetch_one(&mut *conn)
+            .await?;
+
+    let download_target = compute_imdb_poster(
+        current_poster_origin.as_deref(),
+        details.primary_image.as_ref().map(|image| image.url.as_str()),
+        show_id,
+        "show",
+    );
+
+    let overview = details
+        .plot
+        .as_ref()
+        .and_then(|plot| plot.plot_text.as_ref())
+        .and_then(|text| text.plain_text.as_deref());
+    let year = details.release_year.as_ref().and_then(|release| release.year);
+    let rating = imdb_rating(&details.ratings_summary);
+    let genres_json = serde_json::to_string(
+        &details
+            .genres
+            .as_ref()
+            .map(|wrapper| {
+                wrapper
+                    .genres
+                    .iter()
+                    .map(|genre| genre.text.clone())
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default(),
+    )
+    .unwrap_or_else(|_| "[]".to_string());
+    let cast_json = build_imdb_cast_json(&details.principal_credits);
+    let first_air_date = details.release_date.as_ref().and_then(|date| {
+        match (date.year, date.month, date.day) {
+            (Some(y), Some(m), Some(d)) => Some(format!("{y:04}-{m:02}-{d:02}")),
+            _ => None,
+        }
+    });
+
+    if let Some((_size, _url, local_path)) = download_target.as_ref() {
+        sqlx::query(
+            "UPDATE shows SET
+                 provider = 'imdb',
+                 provider_id = ?1,
+                 overview = COALESCE(?2, overview),
+                 year = COALESCE(?3, year),
+                 rating = ?4,
+                 genres = ?5,
+                 top_cast = ?6,
+                 first_air_date = COALESCE(?7, first_air_date),
+                 poster_path = ?8,
+                 poster_origin = 'imdb',
+                 metadata_synced_at = strftime('%s','now')
+             WHERE id = ?9",
+        )
+        .bind(&details.id)
+        .bind(overview)
+        .bind(year)
+        .bind(rating)
+        .bind(&genres_json)
+        .bind(&cast_json)
+        .bind(first_air_date.as_deref())
+        .bind(local_path)
+        .bind(show_id)
+        .execute(&mut *conn)
+        .await?;
+    } else {
+        sqlx::query(
+            "UPDATE shows SET
+                 provider = 'imdb',
+                 provider_id = ?1,
+                 overview = COALESCE(?2, overview),
+                 year = COALESCE(?3, year),
+                 rating = ?4,
+                 genres = ?5,
+                 top_cast = ?6,
+                 first_air_date = COALESCE(?7, first_air_date),
+                 metadata_synced_at = strftime('%s','now')
+             WHERE id = ?8",
+        )
+        .bind(&details.id)
+        .bind(overview)
+        .bind(year)
+        .bind(rating)
+        .bind(&genres_json)
+        .bind(&cast_json)
+        .bind(first_air_date.as_deref())
+        .bind(show_id)
+        .execute(&mut *conn)
+        .await?;
+    }
+
+    Ok(download_target)
+}
+
+fn imdb_rating(ratings: &Option<RatingsNode>) -> Option<f64> {
+    let ratings = ratings.as_ref()?;
+    let votes = ratings.vote_count.unwrap_or(0);
+
+    if votes == 0 {
+        // Unreleased titles: voteCount is 0 (not null). Treat as no rating.
+        return None;
+    }
+
+    ratings.aggregate_rating
+}
+
+fn build_imdb_cast_json(credits: &[PrincipalCredits]) -> String {
+    // Match on category.id == "cast" (stable lowercase id). The response's
+    // category.text is the plural display name ("Stars") and would not match.
+    let cast_block = credits.iter().find(|block| block.category.id == "cast");
+
+    let payload: Vec<serde_json::Value> = cast_block
+        .map(|block| {
+            block
+                .credits
+                .iter()
+                .take(10)
+                .enumerate()
+                .map(|(index, credit)| {
+                    serde_json::json!({
+                        "name": credit.name.name_text.text,
+                        "character": credit.characters.first().map(|character| character.name.clone()),
+                        "order": index,
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    serde_json::to_string(&payload).unwrap_or_else(|_| "[]".to_string())
+}
+
+/// Returns Some((size, source_url, local_filename)) when the row's existing
+/// poster_origin is not `'manual'` AND the details payload has an image
+/// URL we can download.
+fn compute_imdb_poster(
+    current_origin: Option<&str>,
+    image_url: Option<&str>,
+    media_id: i64,
+    kind: &str,
+) -> Option<(PosterSize, String, String)> {
+    if current_origin == Some("manual") {
+        return None;
+    }
+
+    let url = image_url?;
+    let filename = format!("{kind}-{media_id}.jpg");
+
+    Some((PosterSize::Small, url.to_string(), filename))
+}

--- a/src-tauri/src/metadata/dispatch.rs
+++ b/src-tauri/src/metadata/dispatch.rs
@@ -30,11 +30,6 @@ impl ParkReason {
 
 /// Returns the ordered list of providers to try for a given mode and
 /// key state, or a typed `ParkReason` when no provider can run.
-///
-/// While the IMDB module is unimplemented (PR A of the rollout),
-/// `imdb_only` and `prefer_imdb` degrade to `[Tmdb]` when a key is
-/// present, else park as `NoProviderAvailable`. PR B replaces those
-/// branches with real IMDB walks.
 pub fn providers_for_mode(
     mode: &str,
     has_tmdb_key: bool,
@@ -50,20 +45,20 @@ pub fn providers_for_mode(
                 Err(ParkReason::NoProviderAvailable)
             }
         }
-        // Until PR B lands, IMDB modes degrade to TMDB when possible.
-        "imdb_only" | "prefer_imdb" => {
+        "imdb_only" => Ok(vec![Imdb]),
+        "prefer_imdb" => {
             if has_tmdb_key {
-                Ok(vec![Tmdb])
+                Ok(vec![Imdb, Tmdb])
             } else {
-                Err(ParkReason::NoProviderAvailable)
+                Ok(vec![Imdb])
             }
         }
         _ => {
-            // prefer_tmdb (default). IMDB fallback arrives in PR B.
+            // prefer_tmdb (default) and unknown modes.
             if has_tmdb_key {
-                Ok(vec![Tmdb])
+                Ok(vec![Tmdb, Imdb])
             } else {
-                Err(ParkReason::NoProviderAvailable)
+                Ok(vec![Imdb])
             }
         }
     }
@@ -91,38 +86,52 @@ mod tests {
     }
 
     #[test]
-    fn imdb_only_without_key_parks_in_pr_a_degrade() {
-        let result = providers_for_mode("imdb_only", false);
-        assert_eq!(result.unwrap_err(), ParkReason::NoProviderAvailable);
+    fn imdb_only_returns_imdb_always() {
+        assert_eq!(providers_for_mode("imdb_only", true).unwrap(), vec![Provider::Imdb]);
+        assert_eq!(providers_for_mode("imdb_only", false).unwrap(), vec![Provider::Imdb]);
     }
 
     #[test]
-    fn imdb_only_with_key_degrades_to_tmdb_in_pr_a() {
-        assert_eq!(providers_for_mode("imdb_only", true).unwrap(), vec![Provider::Tmdb]);
-    }
-
-    #[test]
-    fn prefer_tmdb_with_key_returns_tmdb() {
-        assert_eq!(providers_for_mode("prefer_tmdb", true).unwrap(), vec![Provider::Tmdb]);
-    }
-
-    #[test]
-    fn prefer_tmdb_without_key_parks_in_pr_a() {
-        let result = providers_for_mode("prefer_tmdb", false);
-        assert_eq!(result.unwrap_err(), ParkReason::NoProviderAvailable);
-    }
-
-    #[test]
-    fn prefer_imdb_with_key_returns_tmdb_in_pr_a() {
-        assert_eq!(providers_for_mode("prefer_imdb", true).unwrap(), vec![Provider::Tmdb]);
-    }
-
-    #[test]
-    fn unknown_mode_treated_as_prefer_tmdb_default() {
-        assert_eq!(providers_for_mode("garbage", true).unwrap(), vec![Provider::Tmdb]);
+    fn prefer_tmdb_with_key_returns_tmdb_then_imdb() {
         assert_eq!(
-            providers_for_mode("garbage", false).unwrap_err(),
-            ParkReason::NoProviderAvailable,
+            providers_for_mode("prefer_tmdb", true).unwrap(),
+            vec![Provider::Tmdb, Provider::Imdb],
+        );
+    }
+
+    #[test]
+    fn prefer_tmdb_without_key_returns_imdb_only() {
+        assert_eq!(
+            providers_for_mode("prefer_tmdb", false).unwrap(),
+            vec![Provider::Imdb],
+        );
+    }
+
+    #[test]
+    fn prefer_imdb_with_key_returns_imdb_then_tmdb() {
+        assert_eq!(
+            providers_for_mode("prefer_imdb", true).unwrap(),
+            vec![Provider::Imdb, Provider::Tmdb],
+        );
+    }
+
+    #[test]
+    fn prefer_imdb_without_key_returns_imdb_only() {
+        assert_eq!(
+            providers_for_mode("prefer_imdb", false).unwrap(),
+            vec![Provider::Imdb],
+        );
+    }
+
+    #[test]
+    fn unknown_mode_falls_back_to_prefer_tmdb_default() {
+        assert_eq!(
+            providers_for_mode("garbage", true).unwrap(),
+            vec![Provider::Tmdb, Provider::Imdb],
+        );
+        assert_eq!(
+            providers_for_mode("garbage", false).unwrap(),
+            vec![Provider::Imdb],
         );
     }
 

--- a/src-tauri/src/metadata/imdb.rs
+++ b/src-tauri/src/metadata/imdb.rs
@@ -156,6 +156,280 @@ fn http_err(error: reqwest::Error) -> AppError {
     AppError::Other(format!("imdb http: {error}"))
 }
 
+// ---- GraphQL details ----
+
+const GRAPHQL_URL: &str = "https://caching.graphql.imdb.com/";
+
+const GRAPHQL_QUERY: &str = r#"
+query TitleDetails($id: ID!) {
+  title(id: $id) {
+    id
+    titleText { text }
+    titleType { id }
+    releaseYear { year endYear }
+    releaseDate { day month year }
+    plot { plotText { plainText } }
+    ratingsSummary { aggregateRating voteCount }
+    runtime { seconds }
+    genres { genres { id text } }
+    primaryImage { url width height }
+    principalCredits(filter: { categories: ["director","writer","cast"] }) {
+      category { id text }
+      credits {
+        name { id nameText { text } }
+        ... on Cast { characters { name } }
+      }
+    }
+  }
+}
+"#;
+
+#[derive(Debug, Deserialize)]
+struct GraphQLEnvelope {
+    data: Option<GraphQLData>,
+    #[serde(default)]
+    errors: Vec<GraphQLError>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GraphQLData {
+    title: Option<TitleNode>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GraphQLError {
+    message: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TitleNode {
+    pub id: String,
+    #[serde(default, rename = "titleText")]
+    pub title_text: Option<TextNode>,
+    #[serde(default, rename = "releaseYear")]
+    pub release_year: Option<ReleaseYearNode>,
+    #[serde(default, rename = "releaseDate")]
+    pub release_date: Option<ReleaseDateNode>,
+    #[serde(default)]
+    pub plot: Option<PlotNode>,
+    #[serde(default, rename = "ratingsSummary")]
+    pub ratings_summary: Option<RatingsNode>,
+    #[serde(default)]
+    pub runtime: Option<RuntimeNode>,
+    #[serde(default)]
+    pub genres: Option<GenresWrapper>,
+    #[serde(default, rename = "primaryImage")]
+    pub primary_image: Option<PrimaryImage>,
+    #[serde(default, rename = "principalCredits")]
+    pub principal_credits: Vec<PrincipalCredits>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TextNode {
+    pub text: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ReleaseYearNode {
+    pub year: Option<i32>,
+    #[serde(rename = "endYear")]
+    pub end_year: Option<i32>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ReleaseDateNode {
+    pub day: Option<i32>,
+    pub month: Option<i32>,
+    pub year: Option<i32>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PlotNode {
+    #[serde(rename = "plotText")]
+    pub plot_text: Option<PlotTextNode>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PlotTextNode {
+    #[serde(rename = "plainText")]
+    pub plain_text: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RatingsNode {
+    #[serde(rename = "aggregateRating")]
+    pub aggregate_rating: Option<f64>,
+    #[serde(rename = "voteCount")]
+    pub vote_count: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RuntimeNode {
+    pub seconds: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GenresWrapper {
+    #[serde(default)]
+    pub genres: Vec<GenreNode>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GenreNode {
+    pub text: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PrimaryImage {
+    pub url: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PrincipalCredits {
+    pub category: CategoryNode,
+    #[serde(default)]
+    pub credits: Vec<CreditNode>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CategoryNode {
+    pub id: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreditNode {
+    pub name: NameNode,
+    #[serde(default)]
+    pub characters: Vec<CharacterNode>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct NameNode {
+    #[serde(rename = "nameText")]
+    pub name_text: TextNode,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CharacterNode {
+    pub name: String,
+}
+
+pub async fn fetch_movie_details(client: &Client, imdb_id: &str) -> AppResult<TitleNode> {
+    fetch_details_internal(client, imdb_id).await
+}
+
+pub async fn fetch_show_details(client: &Client, imdb_id: &str) -> AppResult<TitleNode> {
+    fetch_details_internal(client, imdb_id).await
+}
+
+async fn fetch_details_internal(client: &Client, imdb_id: &str) -> AppResult<TitleNode> {
+    let body = serde_json::json!({
+        "operationName": "TitleDetails",
+        "variables": { "id": imdb_id },
+        "query": GRAPHQL_QUERY,
+    });
+
+    let response = client
+        .post(GRAPHQL_URL)
+        .header("Content-Type", "application/json")
+        .json(&body)
+        .send()
+        .await
+        .map_err(http_err)?;
+
+    let status = response.status();
+    if status == StatusCode::ACCEPTED {
+        return Err(AppError::Other(
+            "imdb_waf: graphql returned 202; see CLAUDE.md".to_string(),
+        ));
+    }
+    if !status.is_success() {
+        return Err(AppError::Other(format!(
+            "imdb_rate_limited: graphql {status}"
+        )));
+    }
+
+    let envelope: GraphQLEnvelope = response
+        .json()
+        .await
+        .map_err(|error| AppError::Other(format!("imdb parse: graphql: {error}")))?;
+
+    if let Some(first_error) = envelope.errors.first() {
+        return Err(AppError::Other(format!(
+            "imdb graphql: {}",
+            first_error.message
+        )));
+    }
+
+    let title = envelope
+        .data
+        .and_then(|data| data.title)
+        .ok_or_else(|| AppError::Other(format!("imdb not_found: {imdb_id}")))?;
+
+    if title.title_text.is_none() {
+        return Err(AppError::Other(format!("imdb not_found: {imdb_id}")));
+    }
+
+    Ok(title)
+}
+
+// ---- Poster download ----
+
+#[derive(Debug, Clone, Copy)]
+pub enum PosterSize {
+    Small,
+    Hero,
+}
+
+impl PosterSize {
+    fn segment(self) -> &'static str {
+        match self {
+            PosterSize::Small => "_V1_SX500_",
+            PosterSize::Hero => "_V1_QL90_UX1280_",
+        }
+    }
+}
+
+pub async fn download_poster(
+    client: &Client,
+    image_url: &str,
+    dest: &std::path::Path,
+    size: PosterSize,
+) -> AppResult<()> {
+    use tokio::io::AsyncWriteExt;
+
+    let url = rewrite_size(image_url, size);
+
+    let mut response = client.get(&url).send().await.map_err(http_err)?;
+    if !response.status().is_success() {
+        return Err(AppError::Other(format!(
+            "poster download failed: {} {}",
+            response.status(),
+            url
+        )));
+    }
+
+    if let Some(parent) = dest.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    let mut file = tokio::fs::File::create(dest).await?;
+    while let Some(chunk) = response.chunk().await.map_err(http_err)? {
+        file.write_all(&chunk).await?;
+    }
+    file.flush().await?;
+    Ok(())
+}
+
+fn rewrite_size(url: &str, size: PosterSize) -> String {
+    if let Some(index) = url.rfind("_V1_") {
+        let (head, tail) = url.split_at(index);
+        // Strip everything between `_V1_` and the next `.`, replace with our segment.
+        let dot = tail.rfind('.').unwrap_or(tail.len());
+        return format!("{head}{}{}", size.segment(), &tail[dot..]);
+    }
+    url.to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -171,5 +445,24 @@ mod tests {
     #[test]
     fn slugify_handles_trailing_punctuation() {
         assert_eq!(slugify("The End."), "the_end");
+    }
+
+    #[test]
+    fn rewrite_size_inserts_segment() {
+        let url = "https://m.media-amazon.com/images/M/abc@._V1_.jpg";
+        assert_eq!(
+            rewrite_size(url, PosterSize::Small),
+            "https://m.media-amazon.com/images/M/abc@._V1_SX500_.jpg"
+        );
+        assert_eq!(
+            rewrite_size(url, PosterSize::Hero),
+            "https://m.media-amazon.com/images/M/abc@._V1_QL90_UX1280_.jpg"
+        );
+    }
+
+    #[test]
+    fn rewrite_size_leaves_other_urls_alone() {
+        let url = "https://example.com/image.jpg";
+        assert_eq!(rewrite_size(url, PosterSize::Small), url);
     }
 }

--- a/src-tauri/src/metadata/imdb.rs
+++ b/src-tauri/src/metadata/imdb.rs
@@ -466,3 +466,65 @@ mod tests {
         assert_eq!(rewrite_size(url, PosterSize::Small), url);
     }
 }
+
+#[cfg(test)]
+mod fixture_tests {
+    use super::*;
+
+    #[test]
+    fn parses_suggestion_movie_response() {
+        let raw = include_str!("../../tests/fixtures/imdb-suggestion-movie.json");
+        let envelope: SuggestionEnvelope = serde_json::from_str(raw).unwrap();
+        assert_eq!(envelope.d.len(), 3);
+        let movies: Vec<_> = envelope
+            .d
+            .iter()
+            .filter(|entry| entry.id.starts_with("tt") && entry.qid.as_deref() == Some("movie"))
+            .collect();
+        assert_eq!(movies.len(), 2);
+        assert_eq!(movies[0].id, "tt0133093");
+        assert_eq!(movies[0].l.as_deref(), Some("The Matrix"));
+        assert_eq!(movies[0].y, Some(1999));
+    }
+
+    #[test]
+    fn parses_graphql_movie_response() {
+        let raw = include_str!("../../tests/fixtures/imdb-graphql-movie.json");
+        let envelope: GraphQLEnvelope = serde_json::from_str(raw).unwrap();
+        let title = envelope.data.unwrap().title.unwrap();
+        assert_eq!(title.id, "tt0133093");
+        assert_eq!(title.title_text.as_ref().unwrap().text, "The Matrix");
+        assert_eq!(title.release_year.as_ref().unwrap().year, Some(1999));
+        assert_eq!(title.runtime.as_ref().unwrap().seconds, Some(8160));
+        assert_eq!(
+            title.ratings_summary.as_ref().unwrap().aggregate_rating,
+            Some(8.7),
+        );
+        let cast = title
+            .principal_credits
+            .iter()
+            .find(|credit| credit.category.id == "cast")
+            .unwrap();
+        assert_eq!(cast.credits.len(), 2);
+        assert_eq!(cast.credits[0].characters[0].name, "Neo");
+    }
+
+    #[test]
+    fn parses_graphql_show_response() {
+        let raw = include_str!("../../tests/fixtures/imdb-graphql-show.json");
+        let envelope: GraphQLEnvelope = serde_json::from_str(raw).unwrap();
+        let title = envelope.data.unwrap().title.unwrap();
+        assert_eq!(title.id, "tt0903747");
+        assert_eq!(title.release_year.as_ref().unwrap().end_year, Some(2013));
+    }
+
+    #[test]
+    fn parses_graphql_edge_case_no_rating() {
+        let raw = include_str!("../../tests/fixtures/imdb-graphql-edge.json");
+        let envelope: GraphQLEnvelope = serde_json::from_str(raw).unwrap();
+        let title = envelope.data.unwrap().title.unwrap();
+        assert_eq!(title.ratings_summary.as_ref().unwrap().vote_count, Some(0));
+        assert!(title.runtime.is_none());
+        assert!(title.primary_image.is_none());
+    }
+}

--- a/src-tauri/src/metadata/imdb.rs
+++ b/src-tauri/src/metadata/imdb.rs
@@ -1,0 +1,175 @@
+//! IMDB metadata client.
+//!
+//! HTML scraping of www.imdb.com is blocked by AWS WAF as of late 2025.
+//! This module uses two undocumented JSON endpoints instead:
+//!
+//!   * Suggestion API for search:
+//!     https://v3.sg.media-imdb.com/suggestion/<letter>/<slug>.json
+//!   * GraphQL for details:
+//!     https://caching.graphql.imdb.com/
+//!
+//! ## TOS disclaimer
+//!
+//! The GraphQL response carries this disclaimer on every payload:
+//!
+//! > Public, commercial, and/or non-private use of the IMDb data
+//! > provided by this API is not allowed. For limited non-commercial use
+//! > of IMDb data and the associated requirements see
+//! > https://help.imdb.com/article/imdb/general-information/can-i-use-imdb-data-in-my-software/G5JTRESSHJBBHTGX
+//!
+//! rustflix neither redistributes IMDb data nor uses it commercially.
+//! Users are responsible for their own compliance with the linked terms.
+//! The tmdb_only mode remains a functional escape hatch.
+
+use reqwest::{Client, StatusCode};
+use serde::Deserialize;
+
+use crate::error::{AppError, AppResult};
+use crate::metadata::dispatch::Provider;
+use crate::metadata::matching::MatchCandidate;
+
+const SUGGESTION_BASE: &str = "https://v3.sg.media-imdb.com/suggestion";
+
+#[derive(Debug, Deserialize)]
+struct SuggestionEnvelope {
+    #[serde(default)]
+    d: Vec<SuggestionEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SuggestionEntry {
+    id: String,
+    #[serde(default)]
+    l: Option<String>,
+    #[serde(default)]
+    y: Option<i32>,
+    #[serde(default)]
+    qid: Option<String>,
+}
+
+pub async fn search_movie(
+    client: &Client,
+    title: &str,
+    year: Option<i32>,
+) -> AppResult<Vec<MatchCandidate>> {
+    search_internal(client, title, year, &["movie"]).await
+}
+
+pub async fn search_show(
+    client: &Client,
+    title: &str,
+    year: Option<i32>,
+) -> AppResult<Vec<MatchCandidate>> {
+    search_internal(client, title, year, &["tvSeries", "tvMiniSeries"]).await
+}
+
+async fn search_internal(
+    client: &Client,
+    title: &str,
+    year: Option<i32>,
+    qid_filter: &[&str],
+) -> AppResult<Vec<MatchCandidate>> {
+    let slug = slugify(title);
+    if slug.is_empty() {
+        return Ok(vec![]);
+    }
+
+    // Try year-augmented slug first (better CDN filtering), fall back to plain slug.
+    let envelope = match year {
+        Some(year_value) => {
+            let augmented = format!("{slug}_{year_value}");
+            let result = fetch_suggestion(client, &augmented).await?;
+            if result.d.is_empty() {
+                fetch_suggestion(client, &slug).await?
+            } else {
+                result
+            }
+        }
+        None => fetch_suggestion(client, &slug).await?,
+    };
+
+    Ok(envelope
+        .d
+        .into_iter()
+        .filter(|entry| entry.id.starts_with("tt"))
+        .filter(|entry| match entry.qid.as_deref() {
+            Some(qid) => qid_filter.contains(&qid),
+            None => false,
+        })
+        .filter_map(|entry| {
+            entry.l.map(|title| MatchCandidate {
+                provider: Provider::Imdb,
+                provider_id: entry.id,
+                title,
+                year: entry.y,
+            })
+        })
+        .collect())
+}
+
+async fn fetch_suggestion(client: &Client, slug: &str) -> AppResult<SuggestionEnvelope> {
+    let first = slug.chars().next().unwrap_or('a');
+    let shard = first.to_lowercase().next().unwrap_or('a');
+    let url = format!("{SUGGESTION_BASE}/{shard}/{slug}.json");
+
+    let response = client.get(&url).send().await.map_err(http_err)?;
+    let status = response.status();
+    if status == StatusCode::ACCEPTED {
+        return Err(AppError::Other(
+            "imdb_waf: suggestion endpoint returned 202; see CLAUDE.md".to_string(),
+        ));
+    }
+    if !status.is_success() {
+        return Err(AppError::Other(format!(
+            "imdb_rate_limited: suggestion {status}"
+        )));
+    }
+    response
+        .json::<SuggestionEnvelope>()
+        .await
+        .map_err(|error| AppError::Other(format!("imdb parse: suggestion: {error}")))
+}
+
+/// Lowercase + non-alphanumeric → `_`, no trailing underscore.
+fn slugify(title: &str) -> String {
+    let mut output = String::with_capacity(title.len());
+    let mut last_was_underscore = false;
+    for character in title.chars() {
+        if character.is_ascii_alphanumeric() {
+            output.push(character.to_ascii_lowercase());
+            last_was_underscore = false;
+        } else if !last_was_underscore && !output.is_empty() {
+            output.push('_');
+            last_was_underscore = true;
+        }
+    }
+    if output.ends_with('_') {
+        output.pop();
+    }
+    output
+}
+
+fn http_err(error: reqwest::Error) -> AppError {
+    if error.is_status() {
+        return AppError::Other(format!("imdb_rate_limited: {error}"));
+    }
+    AppError::Other(format!("imdb http: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slugify_lowercases_and_replaces_non_alnum() {
+        assert_eq!(slugify("The Matrix"), "the_matrix");
+        assert_eq!(slugify("It's a Wonderful Life"), "it_s_a_wonderful_life");
+        assert_eq!(slugify("Pokémon"), "pok_mon");
+        assert_eq!(slugify("Dune (2021)"), "dune_2021");
+    }
+
+    #[test]
+    fn slugify_handles_trailing_punctuation() {
+        assert_eq!(slugify("The End."), "the_end");
+    }
+}

--- a/src-tauri/src/metadata/matching.rs
+++ b/src-tauri/src/metadata/matching.rs
@@ -4,8 +4,11 @@
 use serde::{Deserialize, Serialize};
 use unicode_normalization::UnicodeNormalization;
 
+use crate::metadata::dispatch::Provider;
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MatchCandidate {
+    pub provider: Provider,
     pub provider_id: String,
     pub title: String,
     pub year: Option<i32>,
@@ -90,6 +93,7 @@ mod tests {
 
     fn candidate(id: &str, title: &str, year: Option<i32>) -> MatchCandidate {
         MatchCandidate {
+            provider: Provider::Tmdb,
             provider_id: id.to_string(),
             title: title.to_string(),
             year,

--- a/src-tauri/src/metadata/mod.rs
+++ b/src-tauri/src/metadata/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod apply;
 pub mod dispatch;
+pub mod imdb;
 pub mod matching;
 pub mod queries;
 pub mod tmdb;

--- a/src-tauri/src/metadata/tmdb.rs
+++ b/src-tauri/src/metadata/tmdb.rs
@@ -7,6 +7,7 @@ use serde::Deserialize;
 use tokio::io::AsyncWriteExt;
 
 use crate::error::{AppError, AppResult};
+use crate::metadata::dispatch::Provider;
 use crate::metadata::matching::MatchCandidate;
 
 const API_BASE: &str = "https://api.themoviedb.org/3";
@@ -97,6 +98,7 @@ pub async fn search_movie(
         .results
         .into_iter()
         .map(|raw| MatchCandidate {
+            provider: Provider::Tmdb,
             provider_id: raw.id.to_string(),
             title: raw.title,
             year: parse_year(raw.release_date.as_deref()),
@@ -126,6 +128,7 @@ pub async fn search_show(
         .results
         .into_iter()
         .map(|raw| MatchCandidate {
+            provider: Provider::Tmdb,
             provider_id: raw.id.to_string(),
             title: raw.name,
             year: parse_year(raw.first_air_date.as_deref()),

--- a/src-tauri/src/metadata/worker.rs
+++ b/src-tauri/src/metadata/worker.rs
@@ -18,7 +18,7 @@ use tokio::time::sleep;
 
 use crate::error::{AppError, AppResult};
 use crate::metadata::dispatch::{providers_for_mode, ParkReason, Provider};
-use crate::metadata::{apply, matching, queries, tmdb};
+use crate::metadata::{apply, imdb, matching, queries, tmdb};
 use crate::queries as app_queries;
 
 const PACING_MS: u64 = 250;
@@ -34,13 +34,14 @@ enum Outcome {
     NoMatch,
 }
 
-/// A pending poster download, queued post-tx as best-effort. The `size`
-/// field is reserved for the future IMDB poster-size enum (PR B); for
-/// now it's an `Option<&'static str>` placeholder set to None for TMDB.
+/// A pending poster download, queued post-tx as best-effort. `size` is
+/// the discriminator: `None` means "TMDB path, route through
+/// `tmdb::download_poster`"; `Some(PosterSize)` means "IMDB path, route
+/// through `imdb::download_poster`".
 pub struct PosterDownload {
     pub url: String,
     pub filename: String,
-    pub size: Option<&'static str>,
+    pub size: Option<crate::metadata::imdb::PosterSize>,
 }
 
 /// Match result from a per-kind dispatcher (e.g. `dispatch_tmdb_movie`).
@@ -181,9 +182,7 @@ async fn dispatch_provider(
 ) -> AppResult<Outcome> {
     match provider {
         Provider::Tmdb => dispatch_tmdb(pool, http, app, api_key, job).await,
-        Provider::Imdb => Err(AppError::Other(
-            "imdb provider not implemented in PR A".to_string(),
-        )),
+        Provider::Imdb => dispatch_imdb(pool, http, app, job).await,
     }
 }
 
@@ -339,6 +338,149 @@ async fn dispatch_tmdb_show(
             }),
             _ => None,
         },
+    })
+}
+
+async fn dispatch_imdb(
+    pool: &SqlitePool,
+    http: &reqwest::Client,
+    app: &AppHandle,
+    job: &queries::MetadataJob,
+) -> AppResult<Outcome> {
+    let posters_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|error| AppError::Other(format!("app_data_dir: {error}")))?
+        .join("posters");
+
+    let result = match job.kind.as_str() {
+        "movie" => dispatch_imdb_movie(pool, http, job.media_id).await?,
+        "show" => dispatch_imdb_show(pool, http, job.media_id).await?,
+        other => {
+            return Err(AppError::Other(format!("unknown job kind: {other}")));
+        }
+    };
+
+    match result {
+        MatchOutcome::NoMatch => Ok(Outcome::NoMatch),
+        MatchOutcome::Matched { poster } => {
+            if let Some(download) = poster {
+                let dest = posters_dir.join(&download.filename);
+                let size = download
+                    .size
+                    .unwrap_or(crate::metadata::imdb::PosterSize::Small);
+                if let Err(error) = imdb::download_poster(http, &download.url, &dest, size).await {
+                    eprintln!("imdb poster download failed for {dest:?}: {error}");
+                }
+            }
+            Ok(Outcome::Matched)
+        }
+    }
+}
+
+async fn dispatch_imdb_movie(
+    pool: &SqlitePool,
+    http: &reqwest::Client,
+    movie_id: i64,
+) -> AppResult<MatchOutcome> {
+    let row: Option<(i64, String, Option<i32>)> = sqlx::query_as(
+        "SELECT metadata_locked, title, year FROM movies WHERE id = ?1",
+    )
+    .bind(movie_id)
+    .fetch_optional(pool)
+    .await?;
+
+    let Some((locked, title, year)) = row else {
+        return Ok(MatchOutcome::NoMatch);
+    };
+    if locked != 0 {
+        return Ok(MatchOutcome::NoMatch);
+    }
+
+    let candidates = imdb::search_movie(http, &title, year).await?;
+    let Some(pick) = matching::pick_confident_match(&title, year, &candidates) else {
+        return Ok(MatchOutcome::NoMatch);
+    };
+
+    let details = imdb::fetch_movie_details(http, &pick.provider_id).await?;
+
+    let mut tx = pool.begin().await?;
+
+    let still_locked: i64 = sqlx::query_scalar(
+        "SELECT metadata_locked FROM movies WHERE id = ?1",
+    )
+    .bind(movie_id)
+    .fetch_one(&mut *tx)
+    .await?;
+    if still_locked != 0 {
+        tx.rollback().await?;
+        return Ok(MatchOutcome::NoMatch);
+    }
+
+    let download_target = apply::apply_imdb_movie_details(&mut *tx, movie_id, &details).await?;
+
+    queries::delete_in_tx(&mut *tx, "movie", movie_id).await?;
+    tx.commit().await?;
+
+    Ok(MatchOutcome::Matched {
+        poster: download_target.map(|(size, url, filename)| PosterDownload {
+            url,
+            filename,
+            size: Some(size),
+        }),
+    })
+}
+
+async fn dispatch_imdb_show(
+    pool: &SqlitePool,
+    http: &reqwest::Client,
+    show_id: i64,
+) -> AppResult<MatchOutcome> {
+    let row: Option<(i64, String, Option<i32>)> = sqlx::query_as(
+        "SELECT metadata_locked, title, year FROM shows WHERE id = ?1",
+    )
+    .bind(show_id)
+    .fetch_optional(pool)
+    .await?;
+
+    let Some((locked, title, year)) = row else {
+        return Ok(MatchOutcome::NoMatch);
+    };
+    if locked != 0 {
+        return Ok(MatchOutcome::NoMatch);
+    }
+
+    let candidates = imdb::search_show(http, &title, year).await?;
+    let Some(pick) = matching::pick_confident_match(&title, year, &candidates) else {
+        return Ok(MatchOutcome::NoMatch);
+    };
+
+    let details = imdb::fetch_show_details(http, &pick.provider_id).await?;
+
+    let mut tx = pool.begin().await?;
+
+    let still_locked: i64 = sqlx::query_scalar(
+        "SELECT metadata_locked FROM shows WHERE id = ?1",
+    )
+    .bind(show_id)
+    .fetch_one(&mut *tx)
+    .await?;
+    if still_locked != 0 {
+        tx.rollback().await?;
+        return Ok(MatchOutcome::NoMatch);
+    }
+
+    let download_target = apply::apply_imdb_show_details(&mut *tx, show_id, &details).await?;
+
+    queries::delete_in_tx(&mut *tx, "show", show_id).await?;
+    tx.commit().await?;
+
+    Ok(MatchOutcome::Matched {
+        poster: download_target.map(|(size, url, filename)| PosterDownload {
+            url,
+            filename,
+            size: Some(size),
+        }),
     })
 }
 

--- a/src-tauri/src/metadata/worker.rs
+++ b/src-tauri/src/metadata/worker.rs
@@ -100,6 +100,49 @@ async fn run(
             continue;
         }
 
+        // Fast path: hand-linked rows bypass mode dispatch. The user's
+        // pick (or a prior successful link) is the source of truth.
+        if let Some(linked) = read_linked_provider(&pool, &job).await? {
+            let key_for_call = api_key.as_deref().unwrap_or("");
+
+            match dispatch_provider(linked, &pool, &http, &app, key_for_call, &job).await {
+                Ok(Outcome::Matched) => {
+                    sleep(Duration::from_millis(PACING_MS)).await;
+                    continue;
+                }
+                Ok(Outcome::NoMatch) => {
+                    let mut tx = pool.begin().await?;
+                    queries::delete_in_tx(&mut *tx, &job.kind, job.media_id).await?;
+                    tx.commit().await?;
+
+                    sleep(Duration::from_millis(PACING_MS)).await;
+                    continue;
+                }
+                Err(error) => {
+                    let error_string = error.to_string();
+                    if error_string.starts_with("auth_required")
+                        || error_string.starts_with("tmdb_auth_required")
+                    {
+                        let key_now =
+                            app_queries::get_app_setting(&pool, "tmdb_api_key").await?;
+                        if key_now == key_at_job_start {
+                            app_queries::set_app_setting(&pool, "tmdb_auth_bad", "1").await?;
+                        }
+                    }
+                    queries::record_failure(
+                        &pool,
+                        &job.kind,
+                        job.media_id,
+                        &error_string,
+                    )
+                    .await?;
+
+                    sleep(Duration::from_millis(PACING_MS)).await;
+                    continue;
+                }
+            }
+        }
+
         let providers = match providers_for_mode(&mode, api_key.is_some()) {
             Ok(list) => list,
             Err(reason) => {
@@ -481,6 +524,31 @@ async fn dispatch_imdb_show(
             filename,
             size: Some(size),
         }),
+    })
+}
+
+async fn read_linked_provider(
+    pool: &SqlitePool,
+    job: &queries::MetadataJob,
+) -> AppResult<Option<Provider>> {
+    let table = match job.kind.as_str() {
+        "movie" => "movies",
+        "show" => "shows",
+        _ => return Ok(None),
+    };
+
+    let provider: Option<String> = sqlx::query_scalar(&format!(
+        "SELECT provider FROM {table} WHERE id = ?1"
+    ))
+    .bind(job.media_id)
+    .fetch_optional(pool)
+    .await?
+    .flatten();
+
+    Ok(match provider.as_deref() {
+        Some("tmdb") => Some(Provider::Tmdb),
+        Some("imdb") => Some(Provider::Imdb),
+        _ => None,
     })
 }
 

--- a/src-tauri/tests/fixtures/imdb-graphql-edge.json
+++ b/src-tauri/tests/fixtures/imdb-graphql-edge.json
@@ -1,0 +1,17 @@
+{
+  "data": {
+    "title": {
+      "id": "tt31378509",
+      "titleText": { "text": "Dune Part Three" },
+      "titleType": { "id": "movie" },
+      "releaseYear": { "year": 2026, "endYear": null },
+      "releaseDate": null,
+      "plot": null,
+      "ratingsSummary": { "aggregateRating": null, "voteCount": 0 },
+      "runtime": null,
+      "genres": { "genres": [] },
+      "primaryImage": null,
+      "principalCredits": []
+    }
+  }
+}

--- a/src-tauri/tests/fixtures/imdb-graphql-movie.json
+++ b/src-tauri/tests/fixtures/imdb-graphql-movie.json
@@ -1,0 +1,29 @@
+{
+  "data": {
+    "title": {
+      "id": "tt0133093",
+      "titleText": { "text": "The Matrix" },
+      "titleType": { "id": "movie" },
+      "releaseYear": { "year": 1999, "endYear": null },
+      "releaseDate": { "day": 31, "month": 3, "year": 1999 },
+      "plot": { "plotText": { "plainText": "Neo discovers reality is a simulation." } },
+      "ratingsSummary": { "aggregateRating": 8.7, "voteCount": 2000000 },
+      "runtime": { "seconds": 8160 },
+      "genres": { "genres": [{ "id": "action", "text": "Action" }, { "id": "scifi", "text": "Sci-Fi" }] },
+      "primaryImage": { "url": "https://m.media-amazon.com/images/M/matrix@._V1_.jpg", "width": 2100, "height": 3156 },
+      "principalCredits": [
+        {
+          "category": { "id": "director", "text": "Directors" },
+          "credits": [{ "name": { "id": "nm0905152", "nameText": { "text": "Lana Wachowski" } } }]
+        },
+        {
+          "category": { "id": "cast", "text": "Stars" },
+          "credits": [
+            { "name": { "id": "nm0000206", "nameText": { "text": "Keanu Reeves" } }, "characters": [{ "name": "Neo" }] },
+            { "name": { "id": "nm0000401", "nameText": { "text": "Laurence Fishburne" } }, "characters": [{ "name": "Morpheus" }] }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/src-tauri/tests/fixtures/imdb-graphql-show.json
+++ b/src-tauri/tests/fixtures/imdb-graphql-show.json
@@ -1,0 +1,24 @@
+{
+  "data": {
+    "title": {
+      "id": "tt0903747",
+      "titleText": { "text": "Breaking Bad" },
+      "titleType": { "id": "tvSeries" },
+      "releaseYear": { "year": 2008, "endYear": 2013 },
+      "releaseDate": { "day": 20, "month": 1, "year": 2008 },
+      "plot": { "plotText": { "plainText": "Chemistry teacher cooks meth." } },
+      "ratingsSummary": { "aggregateRating": 9.5, "voteCount": 2000000 },
+      "runtime": { "seconds": 2880 },
+      "genres": { "genres": [{ "id": "crime", "text": "Crime" }, { "id": "drama", "text": "Drama" }] },
+      "primaryImage": { "url": "https://m.media-amazon.com/images/M/bb@._V1_.jpg", "width": 1600, "height": 2400 },
+      "principalCredits": [
+        {
+          "category": { "id": "cast", "text": "Stars" },
+          "credits": [
+            { "name": { "id": "nm0186505", "nameText": { "text": "Bryan Cranston" } }, "characters": [{ "name": "Walter White" }] }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/src-tauri/tests/fixtures/imdb-suggestion-movie.json
+++ b/src-tauri/tests/fixtures/imdb-suggestion-movie.json
@@ -1,0 +1,9 @@
+{
+  "d": [
+    { "id": "tt0133093", "l": "The Matrix", "y": 1999, "qid": "movie" },
+    { "id": "tt0234215", "l": "The Matrix Reloaded", "y": 2003, "qid": "movie" },
+    { "id": "nm0905152", "l": "Lana Wachowski" }
+  ],
+  "q": "the_matrix",
+  "v": 1
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -70,6 +70,7 @@ export interface MetadataStatusCounts {
 }
 
 export interface MatchCandidate {
+  provider: 'tmdb' | 'imdb';
   provider_id: string;
   title: string;
   year: number | null;
@@ -181,10 +182,20 @@ export const api = {
     invoke<void>('refresh_metadata', { kind, id }),
   unlinkMetadata: (kind: 'show' | 'movie', id: number) =>
     invoke<void>('unlink_metadata', { kind, id }),
-  metadataSearch: (kind: 'show' | 'movie', query: string, year: number | null) =>
-    invoke<MatchCandidate[]>('metadata_search', { kind, query, year }),
-  linkMetadata: (kind: 'show' | 'movie', mediaId: number, providerId: string) =>
-    invoke<void>('link_metadata', { kind, mediaId, providerId }),
+  metadataSearch: (
+    kind: 'show' | 'movie',
+    query: string,
+    year: number | null,
+    provider: 'tmdb' | 'imdb',
+  ) =>
+    invoke<MatchCandidate[]>('metadata_search', { kind, query, year, provider }),
+  linkMetadata: (
+    kind: 'show' | 'movie',
+    mediaId: number,
+    provider: 'tmdb' | 'imdb',
+    providerId: string,
+  ) =>
+    invoke<void>('link_metadata', { kind, mediaId, provider, providerId }),
   listNeedsReview: () => invoke<NeedsReviewItem[]>('list_needs_review'),
 
   adminListRows: (table: string, sortColumn?: string, direction?: 'asc' | 'desc') =>

--- a/src/lib/components/MetadataMatchSheet.svelte
+++ b/src/lib/components/MetadataMatchSheet.svelte
@@ -34,7 +34,7 @@
     error = null;
     candidates = [];
     try {
-      candidates = await api.metadataSearch(item.kind, item.title, item.year);
+      candidates = await api.metadataSearch(item.kind, item.title, item.year, 'tmdb');
     } catch (caught) {
       error = String(caught);
     } finally {
@@ -48,7 +48,7 @@
     }
     error = null;
     try {
-      await api.linkMetadata(item.kind, item.id, candidate.provider_id);
+      await api.linkMetadata(item.kind, item.id, 'tmdb', candidate.provider_id);
       onLinked();
       onClose();
     } catch (caught) {


### PR DESCRIPTION
## Summary

- New `metadata::imdb` module hits `v3.sg.media-imdb.com/suggestion` for search and `caching.graphql.imdb.com` for details. No HTML scraping; no new crates (reqwest + serde_json suffice).
- `MatchCandidate` now carries the source provider, so the worker and UI can route on a single field instead of inferring from the ID format.
- `apply_imdb_*` writes the same DB columns as TMDB with `provider = 'imdb'`. Cast filtering matches on stable `category.id == "cast"`; `voteCount == 0` (unreleased titles) is treated as no rating; first_air_date is built from the GraphQL `releaseDate` triple.
- `dispatch_provider` now routes `Provider::Imdb` to a real dispatcher; HTTP stays outside the tx, apply + delete merged in one tx (same shape as TMDB).
- `providers_for_mode` returns the real IMDB walks; PR-A's "degrade to Tmdb" stub is gone.
- Hand-linked rows (those that already have provider + provider_id set) take a fast path that bypasses mode dispatch entirely — the user's manual pick is authoritative regardless of the current ``metadata_mode``. Errors on that path still race-guard-flip ``tmdb_auth_bad`` so the settings banner remains accurate.
- ``metadata_search`` and ``link_metadata`` Tauri commands take a ``provider`` parameter; the frontend ``MatchCandidate`` interface gains a ``provider`` field. ``MetadataMatchSheet`` defaults to ``'tmdb'`` until fix/46 lands the provider toggle.
- 5 fixture-driven parser tests (suggestion API + GraphQL details, including an unreleased-title edge case) lock down the IMDB JSON parsing surface.

## Test plan

- [ ] ``cargo test --lib metadata`` — 35 tests pass.
- [ ] ``CI=true pnpm check`` — 0 errors.
- [ ] Settings → Metadata: switch to ``imdb_only`` and ``prefer_imdb`` and confirm pending jobs drain via IMDB (look for ``provider = 'imdb'`` in DB after scan).
- [ ] Switch to ``tmdb_only`` without a key configured and confirm jobs park as ``no_provider_available`` (not ``tmdb_auth_required``).
- [ ] Hand-link a row to a deliberately wrong IMDB id from the match sheet; observe the fast path picks IMDB regardless of mode.
- [ ] Trigger a 401 from TMDB (bad key) on a row that's been hand-linked to TMDB; confirm the settings page shows the auth-bad banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)