### PR TITLE
Metadata fix/46: match-sheet provider toggle + auth-bad banner

### DIFF
--- a/src/lib/components/MetadataMatchSheet.svelte
+++ b/src/lib/components/MetadataMatchSheet.svelte
@@ -4,6 +4,7 @@
     type MatchCandidate,
     type NeedsReviewItem,
   } from '$lib/api';
+  import { getSetting } from '$lib/settings';
   import { Button } from '$lib/components/ui/button';
   import * as Sheet from '$lib/components/ui/sheet';
 
@@ -16,25 +17,66 @@
 
   let { open = $bindable(), item, onClose, onLinked }: Props = $props();
 
+  let activeProvider = $state<'tmdb' | 'imdb'>('tmdb');
   let candidates = $state<MatchCandidate[]>([]);
   let searching = $state(false);
   let error = $state<string | null>(null);
+  let hasTmdbKey = $state(false);
 
   $effect(() => {
     if (open && item) {
-      void runSearch();
+      void initialise();
     }
   });
+
+  async function initialise() {
+    try {
+      const [mode, key] = await Promise.all([
+        getSetting('metadata_mode'),
+        getSetting('tmdb_api_key'),
+      ]);
+      hasTmdbKey = key !== null && key.length > 0;
+      activeProvider = preferredProviderForMode(mode, hasTmdbKey);
+      await runSearch();
+    } catch (caught) {
+      error = String(caught);
+    }
+  }
+
+  function preferredProviderForMode(
+    mode: string,
+    hasKey: boolean,
+  ): 'tmdb' | 'imdb' {
+    if (mode === 'imdb_only' || mode === 'prefer_imdb') {
+      return 'imdb';
+    }
+
+    if (mode === 'tmdb_only' || mode === 'prefer_tmdb') {
+      if (hasKey) {
+        return 'tmdb';
+      }
+      return 'imdb';
+    }
+
+    return 'tmdb';
+  }
 
   async function runSearch() {
     if (!item) {
       return;
     }
+
     searching = true;
     error = null;
     candidates = [];
+
     try {
-      candidates = await api.metadataSearch(item.kind, item.title, item.year, 'tmdb');
+      candidates = await api.metadataSearch(
+        item.kind,
+        item.title,
+        item.year,
+        activeProvider,
+      );
     } catch (caught) {
       error = String(caught);
     } finally {
@@ -42,13 +84,29 @@
     }
   }
 
+  async function selectProvider(next: 'tmdb' | 'imdb') {
+    if (next === 'tmdb' && !hasTmdbKey) {
+      return;
+    }
+
+    activeProvider = next;
+    await runSearch();
+  }
+
   async function pick(candidate: MatchCandidate) {
     if (!item) {
       return;
     }
+
     error = null;
+
     try {
-      await api.linkMetadata(item.kind, item.id, 'tmdb', candidate.provider_id);
+      await api.linkMetadata(
+        item.kind,
+        item.id,
+        activeProvider,
+        candidate.provider_id,
+      );
       onLinked();
       onClose();
     } catch (caught) {
@@ -66,6 +124,25 @@
       </Sheet.Description>
     </Sheet.Header>
 
+    <div class="mt-4 flex gap-1 rounded-md border border-border bg-card p-1">
+      <button
+        type="button"
+        disabled={!hasTmdbKey}
+        onclick={() => selectProvider('tmdb')}
+        title={!hasTmdbKey ? 'Add a TMDB key under Settings → Metadata' : undefined}
+        class="flex-1 rounded px-3 py-1.5 text-sm transition-colors disabled:opacity-50 {activeProvider === 'tmdb' ? 'bg-primary text-primary-foreground' : 'hover:bg-accent'}"
+      >
+        TMDB
+      </button>
+      <button
+        type="button"
+        onclick={() => selectProvider('imdb')}
+        class="flex-1 rounded px-3 py-1.5 text-sm transition-colors {activeProvider === 'imdb' ? 'bg-primary text-primary-foreground' : 'hover:bg-accent'}"
+      >
+        IMDB
+      </button>
+    </div>
+
     {#if error}
       <p class="mt-3 text-sm text-destructive-foreground">{error}</p>
     {/if}
@@ -74,7 +151,7 @@
       <p class="mt-3 text-sm text-muted-foreground">Searching…</p>
     {:else}
       <ul class="mt-4 flex flex-col gap-2">
-        {#each candidates as candidate (candidate.provider_id)}
+        {#each candidates as candidate (candidate.provider + ':' + candidate.provider_id)}
           <li>
             <button
               type="button"
@@ -82,13 +159,13 @@
               class="w-full rounded-md border border-border bg-background px-3 py-2 text-left text-sm transition-colors hover:bg-accent"
             >
               <div class="font-medium">{candidate.title}</div>
-              {#if candidate.year}
-                <div class="text-xs text-muted-foreground">{candidate.year}</div>
-              {/if}
+              <div class="text-xs text-muted-foreground">
+                {candidate.year ?? '—'} · {candidate.provider.toUpperCase()} · {candidate.provider_id}
+              </div>
             </button>
           </li>
         {/each}
-        {#if candidates.length === 0}
+        {#if candidates.length === 0 && !searching}
           <li class="text-sm text-muted-foreground">No candidates found.</li>
         {/if}
       </ul>

--- a/src/routes/settings/metadata/+page.svelte
+++ b/src/routes/settings/metadata/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { api, type MetadataStatusCounts } from '$lib/api';
   import { getSetting, setSetting, type MetadataMode } from '$lib/settings';
+  import { invoke } from '@tauri-apps/api/core';
   import { Button } from '$lib/components/ui/button';
   import {
     Card,
@@ -19,6 +20,7 @@
   let savingMode = $state(false);
   let counts = $state<MetadataStatusCounts | null>(null);
   let error = $state<string | null>(null);
+  let authBad = $state(false);
 
   const MODE_LABELS: Record<MetadataMode, string> = {
     off: 'Off (no metadata sync)',
@@ -34,15 +36,17 @@
 
   async function load() {
     try {
-      const [keyResult, modeResult, countsResult] = await Promise.all([
+      const [keyResult, modeResult, countsResult, authBadResult] = await Promise.all([
         getSetting('tmdb_api_key'),
         getSetting('metadata_mode'),
         api.metadataStatusCounts(),
+        invoke<string | null>('get_app_setting', { key: 'tmdb_auth_bad' }),
       ]);
       savedKey = keyResult;
       mode = modeResult;
       counts = countsResult;
       keyDraft = savedKey ?? '';
+      authBad = authBadResult === '1';
     } catch (caught) {
       error = String(caught);
     }
@@ -90,6 +94,14 @@
       class="mb-6 rounded-md border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive-foreground"
     >
       {error}
+    </div>
+  {/if}
+
+  {#if authBad && mode !== 'off' && mode !== 'imdb_only'}
+    <div
+      class="mb-6 rounded-md border border-yellow-500/30 bg-yellow-500/10 px-4 py-3 text-sm text-yellow-200"
+    >
+      Your TMDB key was rejected on the last sync attempt. Paste a new key below to resume.
     </div>
   {/if}
 


### PR DESCRIPTION
## Summary

- Two-tab UI on the Needs-review match sheet (TMDB / IMDB). The default tab follows the active ``metadata_mode``: IMDB-mode → IMDB, TMDB-mode + key → TMDB, TMDB-mode without key → IMDB. TMDB tab disabled (with tooltip) when no key is stored.
- Picking a candidate calls ``link_metadata`` with the active provider, so the hand-link is authoritative on subsequent worker passes (the fast path added in fix/45 picks it up).
- ``tmdb_auth_bad`` yellow banner on Settings → Metadata when the worker has hit a 401 since the last key save. Hidden when ``mode === 'off'`` or ``mode === 'imdb_only'`` (TMDB irrelevant). Cleared automatically by ``on_setting_changed`` when the user saves a new key.
- Frontend-only PR; no backend changes. Closes out the IMDB-fallback rollout (PRs #41, #42, this one).

## Test plan

- [ ] Open Needs-review on a row in TMDB-only mode with a key → sheet defaults to TMDB.
- [ ] Same row in IMDB-only mode → sheet defaults to IMDB, TMDB tab disabled if no key.
- [ ] Switch tabs mid-search → candidate list refetches with the new provider.
- [ ] Pick an IMDB candidate while in ``tmdb_only`` mode → row hand-links to IMDB; worker fast path refreshes via IMDB on next pass.
- [ ] Break the TMDB key (paste garbage, save), force a sync, observe the yellow banner on Settings → Metadata.
- [ ] Save a real key → banner clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)