### PR TITLE
Fix poster 404s with Tauri asset protocol

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1503,6 +1503,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4131,6 +4137,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "http-range",
  "jni 0.21.1",
  "libc",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["protocol-asset"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-updater = "2"
 serde = { version = "1", features = ["derive"] }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -62,23 +62,35 @@ pub async fn scan_libraries(app: AppHandle, db: State<'_, Db>) -> AppResult<Scan
 }
 
 #[tauri::command]
-pub async fn list_movies(db: State<'_, Db>) -> AppResult<Vec<Movie>> {
-    queries::list_movies(&db).await
+pub async fn list_movies(app: AppHandle, db: State<'_, Db>) -> AppResult<Vec<Movie>> {
+    let mut items = queries::list_movies(&db).await?;
+    for movie in items.iter_mut() {
+        movie.poster_path = resolve_poster_path(&app, movie.poster_path.take());
+    }
+    Ok(items)
 }
 
 #[tauri::command]
-pub async fn get_movie(db: State<'_, Db>, id: i64) -> AppResult<Movie> {
-    queries::get_movie(&db, id).await
+pub async fn get_movie(app: AppHandle, db: State<'_, Db>, id: i64) -> AppResult<Movie> {
+    let mut movie = queries::get_movie(&db, id).await?;
+    movie.poster_path = resolve_poster_path(&app, movie.poster_path.take());
+    Ok(movie)
 }
 
 #[tauri::command]
-pub async fn list_shows(db: State<'_, Db>) -> AppResult<Vec<Show>> {
-    queries::list_shows(&db).await
+pub async fn list_shows(app: AppHandle, db: State<'_, Db>) -> AppResult<Vec<Show>> {
+    let mut items = queries::list_shows(&db).await?;
+    for show in items.iter_mut() {
+        show.poster_path = resolve_poster_path(&app, show.poster_path.take());
+    }
+    Ok(items)
 }
 
 #[tauri::command]
-pub async fn get_show(db: State<'_, Db>, id: i64) -> AppResult<Show> {
-    queries::get_show(&db, id).await
+pub async fn get_show(app: AppHandle, db: State<'_, Db>, id: i64) -> AppResult<Show> {
+    let mut show = queries::get_show(&db, id).await?;
+    show.poster_path = resolve_poster_path(&app, show.poster_path.take());
+    Ok(show)
 }
 
 #[tauri::command]
@@ -92,8 +104,22 @@ pub async fn get_episode(db: State<'_, Db>, id: i64) -> AppResult<Episode> {
 }
 
 #[tauri::command]
-pub async fn continue_watching(db: State<'_, Db>) -> AppResult<Vec<ContinueWatchingItem>> {
-    queries::continue_watching(&db, 12).await
+pub async fn continue_watching(
+    app: AppHandle,
+    db: State<'_, Db>,
+) -> AppResult<Vec<ContinueWatchingItem>> {
+    let mut items = queries::continue_watching(&db, 12).await?;
+    for item in items.iter_mut() {
+        match item {
+            ContinueWatchingItem::Movie { movie } => {
+                movie.poster_path = resolve_poster_path(&app, movie.poster_path.take());
+            }
+            ContinueWatchingItem::Episode { show, .. } => {
+                show.poster_path = resolve_poster_path(&app, show.poster_path.take());
+            }
+        }
+    }
+    Ok(items)
 }
 
 #[tauri::command]
@@ -140,6 +166,7 @@ pub async fn play_episode(
 
 #[tauri::command]
 pub async fn update_show_metadata(
+    app: AppHandle,
     db: State<'_, Db>,
     id: i64,
     title: Option<String>,
@@ -147,11 +174,14 @@ pub async fn update_show_metadata(
     overview: Option<String>,
 ) -> AppResult<Show> {
     queries::update_show_metadata(&db, id, title.as_deref(), year, overview.as_deref()).await?;
-    queries::get_show(&db, id).await
+    let mut show = queries::get_show(&db, id).await?;
+    show.poster_path = resolve_poster_path(&app, show.poster_path.take());
+    Ok(show)
 }
 
 #[tauri::command]
 pub async fn update_movie_metadata(
+    app: AppHandle,
     db: State<'_, Db>,
     id: i64,
     title: Option<String>,
@@ -159,7 +189,9 @@ pub async fn update_movie_metadata(
     overview: Option<String>,
 ) -> AppResult<Movie> {
     queries::update_movie_metadata(&db, id, title.as_deref(), year, overview.as_deref()).await?;
-    queries::get_movie(&db, id).await
+    let mut movie = queries::get_movie(&db, id).await?;
+    movie.poster_path = resolve_poster_path(&app, movie.poster_path.take());
+    Ok(movie)
 }
 
 #[tauri::command]
@@ -441,6 +473,28 @@ pub async fn admin_fk_label(
     crate::admin::fk_label(&db, table, label_column, pk_value).await
 }
 
+/// Resolve a stored `poster_path` to an absolute filesystem path.
+///
+/// Two shapes have existed historically:
+///   * Bare filename like `movie-42.jpg` — written by the metadata
+///     sync layer; the file lives in `<app_data>/posters/`.
+///   * Absolute path — written by manual uploads via copy_poster.
+///
+/// `None` stays `None`. An absolute path is returned as-is.
+fn resolve_poster_path(app: &AppHandle, stored: Option<String>) -> Option<String> {
+    let value = stored?;
+    let candidate = std::path::Path::new(&value);
+
+    if candidate.is_absolute() {
+        return Some(value);
+    }
+
+    let app_data_dir = app.path().app_data_dir().ok()?;
+    let resolved = app_data_dir.join("posters").join(&value);
+
+    Some(resolved.to_string_lossy().to_string())
+}
+
 /// Best-effort cleanup of a manual poster file. Only deletes the file when
 /// it sits inside our own `<app_data>/posters/` directory — any other path
 /// is ignored so a malformed `poster_path` can never remove user media.
@@ -479,7 +533,9 @@ pub async fn set_show_poster_from_file(
 ) -> AppResult<Show> {
     let destination = copy_poster(&app, "show", id, &source_path).await?;
     queries::set_show_poster(&db, id, &destination, "manual").await?;
-    queries::get_show(&db, id).await
+    let mut show = queries::get_show(&db, id).await?;
+    show.poster_path = resolve_poster_path(&app, show.poster_path.take());
+    Ok(show)
 }
 
 #[tauri::command]
@@ -491,19 +547,25 @@ pub async fn set_movie_poster_from_file(
 ) -> AppResult<Movie> {
     let destination = copy_poster(&app, "movie", id, &source_path).await?;
     queries::set_movie_poster(&db, id, &destination, "manual").await?;
-    queries::get_movie(&db, id).await
+    let mut movie = queries::get_movie(&db, id).await?;
+    movie.poster_path = resolve_poster_path(&app, movie.poster_path.take());
+    Ok(movie)
 }
 
 #[tauri::command]
-pub async fn reset_show_poster(db: State<'_, Db>, id: i64) -> AppResult<Show> {
+pub async fn reset_show_poster(app: AppHandle, db: State<'_, Db>, id: i64) -> AppResult<Show> {
     queries::reset_show_poster(&db, id).await?;
-    queries::get_show(&db, id).await
+    let mut show = queries::get_show(&db, id).await?;
+    show.poster_path = resolve_poster_path(&app, show.poster_path.take());
+    Ok(show)
 }
 
 #[tauri::command]
-pub async fn reset_movie_poster(db: State<'_, Db>, id: i64) -> AppResult<Movie> {
+pub async fn reset_movie_poster(app: AppHandle, db: State<'_, Db>, id: i64) -> AppResult<Movie> {
     queries::reset_movie_poster(&db, id).await?;
-    queries::get_movie(&db, id).await
+    let mut movie = queries::get_movie(&db, id).await?;
+    movie.poster_path = resolve_poster_path(&app, movie.poster_path.take());
+    Ok(movie)
 }
 
 /// Copy `source_path` into `<app_data>/posters/{kind}-{id}.{ext}` and return

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,7 +22,11 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": null,
+      "assetProtocol": {
+        "enable": true,
+        "scope": ["$APPDATA/**"]
+      }
     }
   },
   "bundle": {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { invoke } from '@tauri-apps/api/core';
+import { convertFileSrc, invoke } from '@tauri-apps/api/core';
 import { open } from '@tauri-apps/plugin-dialog';
 
 export type LibraryKind = 'movies' | 'series' | 'mixed';
@@ -243,6 +243,19 @@ export function formatRuntime(seconds: number | null | undefined): string {
     return `${hours}h ${minutes}m`;
   }
   return `${minutes}m`;
+}
+
+/**
+ * Convert an absolute filesystem path into a URL the webview can load
+ * (Tauri asset protocol). Bare filenames are rejected — the backend
+ * is responsible for resolving those before returning.
+ */
+export function posterUrl(posterPath: string | null | undefined): string | undefined {
+  if (!posterPath) {
+    return undefined;
+  }
+
+  return convertFileSrc(posterPath);
 }
 
 export function progressPct(

--- a/src/lib/components/HeroBanner.svelte
+++ b/src/lib/components/HeroBanner.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { Image as ImageIcon, Pencil, Play, RotateCcw } from '$lib/lucide';
-  import { formatRuntime } from '$lib/api';
+  import { formatRuntime, posterUrl } from '$lib/api';
 
   type Props = {
     title: string;
@@ -84,7 +84,7 @@
   <div class="relative h-[60vh] min-h-[420px] w-full">
     {#if backdrop}
       <img
-        src={backdrop}
+        src={posterUrl(backdrop)}
         alt=""
         class="absolute inset-0 h-full w-full object-cover"
       />

--- a/src/lib/components/PosterCard.svelte
+++ b/src/lib/components/PosterCard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { posterUrl } from '$lib/api';
   import { Play, CheckCircle, Image as ImageIcon } from '$lib/lucide';
 
   type Props = {
@@ -32,7 +33,7 @@
   >
     {#if posterPath}
       <img
-        src={posterPath}
+        src={posterUrl(posterPath)}
         alt={title}
         class="absolute inset-0 h-full w-full object-cover"
         loading="lazy"

--- a/src/routes/films/[id]/edit/+page.svelte
+++ b/src/routes/films/[id]/edit/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { page } from '$app/stores';
-  import { api, pickImageFile, type MetadataPatch, type Movie } from '$lib/api';
+  import { api, pickImageFile, posterUrl, type MetadataPatch, type Movie } from '$lib/api';
   import { Button } from '$lib/components/ui/button';
   import {
     Card,
@@ -207,7 +207,7 @@
           <div class="aspect-[2/3] w-32 shrink-0 overflow-hidden rounded-md border border-border bg-card">
             {#if movie.poster_path}
               <img
-                src={movie.poster_path}
+                src={posterUrl(movie.poster_path)}
                 alt=""
                 class="h-full w-full object-cover"
               />

--- a/src/routes/series/[id]/edit/+page.svelte
+++ b/src/routes/series/[id]/edit/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { page } from '$app/stores';
-  import { api, pickImageFile, type MetadataPatch, type Show } from '$lib/api';
+  import { api, pickImageFile, posterUrl, type MetadataPatch, type Show } from '$lib/api';
   import { Button } from '$lib/components/ui/button';
   import {
     Card,
@@ -228,7 +228,7 @@
           <div class="aspect-[2/3] w-32 shrink-0 overflow-hidden rounded-md border border-border bg-card">
             {#if show.poster_path}
               <img
-                src={show.poster_path}
+                src={posterUrl(show.poster_path)}
                 alt=""
                 class="h-full w-full object-cover"
               />


### PR DESCRIPTION
## Summary

After the IMDB-fallback rollout, posters 404'd in dev: `apply.rs` stores `poster_path` as a bare filename like `show-52.jpg`, and the manual upload path stores an absolute Windows path. The webview can't load either as `<img src=>`.

This PR enables Tauri 2's asset protocol scoped to `$APPDATA/**`, has the backend normalise bare filenames to absolute paths before returning them, and has the frontend wrap every `poster_path` with `convertFileSrc` via a single `posterUrl` helper.

- `tauri.conf.json`: `app.security.assetProtocol` enabled, scope = `$APPDATA/**`.
- `Cargo.toml`: enable the `protocol-asset` feature on the `tauri` crate (Tauri 2 requires it to match the config).
- `commands.rs`: new `resolve_poster_path(app, stored) -> Option<String>` helper. Applied in every command that returns a Movie or Show to the frontend (`list_movies`, `get_movie`, `list_shows`, `get_show`, `continue_watching`, `update_show_metadata`, `update_movie_metadata`, `set_*_poster_from_file`, `reset_*_poster`).
- `api.ts`: new `posterUrl(path)` export wrapping `convertFileSrc`.
- `PosterCard`, `HeroBanner`, films/series edit pages: use `posterUrl(...)` for `<img src=>`.

Note: in this Tauri version the asset protocol is gated by the config + cargo feature only — there is no separate `core:asset` capability permission to add.

## Test plan

- [ ] Restart `pnpm tauri:dev`.
- [ ] Home page / Films / Series: every poster card renders.
- [ ] Series detail page: backdrop renders.
- [ ] Open a movie's edit page: poster preview renders.
- [ ] Upload a manual poster from the edit page: preview updates.
- [ ] DevTools Network tab: no `/show-N.jpg` 404s.

Generated with Claude Code