### PR TITLE
chore: clear three Rust dead-code warnings

### DIFF
--- a/src-tauri/src/metadata/imdb.rs
+++ b/src-tauri/src/metadata/imdb.rs
@@ -232,6 +232,8 @@ pub struct TextNode {
 #[derive(Debug, Deserialize)]
 pub struct ReleaseYearNode {
     pub year: Option<i32>,
+    // Captured from IMDB so a future "ended in YYYY" UI can show it without a re-fetch.
+    #[allow(dead_code)]
     #[serde(rename = "endYear")]
     pub end_year: Option<i32>,
 }
@@ -378,6 +380,8 @@ async fn fetch_details_internal(client: &Client, imdb_id: &str) -> AppResult<Tit
 #[derive(Debug, Clone, Copy)]
 pub enum PosterSize {
     Small,
+    // Reserved for the future backdrop / hero rendering path.
+    #[allow(dead_code)]
     Hero,
 }
 

--- a/src-tauri/src/queries.rs
+++ b/src-tauri/src/queries.rs
@@ -591,6 +591,7 @@ pub fn validate(key: &str, value: Option<&str>) -> AppResult<()> {
 /// `get_app_setting` callers when the row is missing. The TS wrapper has
 /// the parsed-type defaults; this is a parallel string version for the
 /// Rust read path.
+#[allow(dead_code)] // Reserved for a settings-defaults UI; consumers TBD.
 pub fn default_for(key: &str) -> Option<&'static str> {
     match key {
         "metadata_mode" => Some("prefer_tmdb"),


### PR DESCRIPTION
## Summary

After the IMDB-fallback rollout, ``cargo check`` ended with three dead-code warnings on items placed for near-term future use:

- ``ReleaseYearNode.end_year`` (``metadata/imdb.rs``) — parsed from IMDB so a future "ended in YYYY" UI can show it without re-fetching the title details.
- ``PosterSize::Hero`` — reserved for the backdrop / hero rendering path; ``Small`` is the only variant the worker currently consumes.
- ``queries::default_for`` — string-side parallel to the TS ``SETTINGS`` defaults map; will feed a settings-defaults UI when one lands.

Each gets a single ``#[allow(dead_code)]`` annotation with a one-line note. Annotating beats deleting because the backlog (TODO.md) has a real consumer for each.

## Test plan

- [ ] ``cargo check`` exits with zero warnings on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)